### PR TITLE
Fixed #79 - event handlers firing twice

### DIFF
--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
@@ -132,18 +132,8 @@ export class ClustererComponent extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setClustererCallback = (): void => {
-    if (this.state.markerClusterer !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.markerClusterer
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.markerClusterer)
-      }
+    if (this.state.markerClusterer !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.markerClusterer)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
@@ -66,14 +66,6 @@ export class DirectionsRenderer extends React.PureComponent<
     if (this.state.directionsRenderer !== null) {
       this.state.directionsRenderer.setMap(this.context)
 
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.directionsRenderer
-      })
-
       if (this.props.onLoad) {
         this.props.onLoad(this.state.directionsRenderer)
       }

--- a/packages/react-google-maps-api/src/components/directions/DirectionsService.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsService.tsx
@@ -29,15 +29,8 @@ export class DirectionsService extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setDirectionsServiceCallback = () => {
-    if (this.state.directionsService !== null) {
-      this.state.directionsService.route(
-        this.props.options,
-        this.props.callback
-      )
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.directionsService)
-      }
+    if (this.state.directionsService !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.directionsService)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/Circle.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Circle.tsx
@@ -90,18 +90,8 @@ export class Circle extends React.PureComponent<CircleProps, CircleState> {
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setCircleCallback = () => {
-    if (this.state.circle !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.circle
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.circle)
-      }
+    if (this.state.circle !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.circle)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.md
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.md
@@ -21,6 +21,7 @@ const ScriptLoaded = require("../../docs/ScriptLoaded").default;
       onLoad={drawingManager => {
         console.log(drawingManager)
       }}
+      onPolygonComplete={(polygon) => console.log({polygon})}
     />
   </GoogleMap>
 </ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
@@ -74,18 +74,8 @@ export class DrawingManager extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setDrawingManagerCallback = () => {
-    if (this.state.drawingManager !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.drawingManager
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.drawingManager)
-      }
+    if (this.state.drawingManager !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.drawingManager)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
@@ -89,14 +89,6 @@ export class InfoWindow extends React.PureComponent<
       this.containerElement !== null &&
       this.props.anchor !== null
     ) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.infoWindow
-      })
-
       this.state.infoWindow.setContent(this.containerElement)
 
       this.open(this.state.infoWindow, this.props.anchor)

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -140,18 +140,8 @@ export class Marker extends React.PureComponent<MarkerProps, MarkerState> {
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setMarkerCallback = () => {
-    if (this.state.marker !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.marker
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.marker)
-      }
+    if (this.state.marker !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.marker)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
@@ -91,18 +91,8 @@ export class Polygon extends React.PureComponent<PolygonProps, PolygonState> {
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setPolygonCallback = () => {
-    if (this.state.polygon !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.polygon
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.polygon)
-      }
+    if (this.state.polygon !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.polygon)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/Polyline.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polyline.tsx
@@ -87,18 +87,8 @@ export class Polyline extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setPolylineCallback = () => {
-    if (this.state.polyline !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.polyline
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.polyline)
-      }
+    if (this.state.polyline !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.polyline)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/drawing/Rectangle.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Rectangle.tsx
@@ -89,18 +89,8 @@ export class Rectangle extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setRectangleCallback = () => {
-    if (this.state.rectangle !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.rectangle
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.rectangle)
-      }
+    if (this.state.rectangle !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.rectangle)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.tsx
+++ b/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.tsx
@@ -56,18 +56,8 @@ export class HeatmapLayer extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setHeatmapLayerCallback = () => {
-    if (this.state.heatmapLayer !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.heatmapLayer
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.heatmapLayer)
-      }
+    if (this.state.heatmapLayer !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.heatmapLayer)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
+++ b/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
@@ -56,14 +56,6 @@ export class KmlLayer extends PureComponent<KmlLayerProps, KmlLayerState> {
     if (this.state.kmlLayer !== null) {
       this.state.kmlLayer.setMap(this.context)
 
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.kmlLayer
-      })
-
       if (this.props.onLoad) {
         this.props.onLoad(this.state.kmlLayer)
       }

--- a/packages/react-google-maps-api/src/components/maps/BicyclingLayer.tsx
+++ b/packages/react-google-maps-api/src/components/maps/BicyclingLayer.tsx
@@ -15,9 +15,6 @@ export class BicyclingLayer extends React.PureComponent<
   BicyclingLayerProps,
   BicyclingLayerState
 > {
-  public static defaultProps = {
-    onLoad: () => {}
-  }
   static contextType = MapContext
 
   state = {
@@ -30,8 +27,11 @@ export class BicyclingLayer extends React.PureComponent<
       // TODO: how is this possibly null if we're doing a null check
       // @ts-ignore
       this.state.bicyclingLayer.setMap(this.context)
-      //@ts-ignore
-      this.props.onLoad(this.state.bicyclingLayer)
+      
+      if (this.props.onLoad) {
+        //@ts-ignore
+        this.props.onLoad(this.state.bicyclingLayer)
+      }
     }
   }
 

--- a/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
+++ b/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
@@ -40,14 +40,6 @@ export class TrafficLayer extends PureComponent<
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setTrafficLayerCallback = () => {
     if (this.state.trafficLayer !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.trafficLayer
-      })
-
       if (this.props.onLoad) {
         // @ts-ignore
         this.props.onLoad(this.state.trafficLayer)

--- a/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
+++ b/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
@@ -52,10 +52,8 @@ export class GroundOverlay extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setGroundOverlayCallback = () => {
-    if (this.state.groundOverlay !== null) {
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.groundOverlay)
-      }
+    if (this.state.groundOverlay !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.groundOverlay)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -76,10 +76,8 @@ export class Autocomplete extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setAutocompleteCallback = () => {
-    if (this.state.autocomplete !== null) {
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.autocomplete)
-      }
+    if (this.state.autocomplete !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.autocomplete)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
@@ -50,18 +50,8 @@ class StandaloneSearchBox extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setSearchBoxCallback = () => {
-    if (this.state.searchBox !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.searchBox
-      })
-
-      if (this.props.onLoad){
-        this.props.onLoad(this.state.searchBox)
-      }
+    if (this.state.searchBox !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.searchBox)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
@@ -101,18 +101,8 @@ export class StreetViewPanorama extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setStreetViewPanoramaCallback = () => {
-    if (this.state.streetViewPanorama !== null) {
-      this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
-        updaterMap,
-        eventMap,
-        prevProps: {},
-        nextProps: this.props,
-        instance: this.state.streetViewPanorama
-      })
-
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.streetViewPanorama)
-      }
+    if (this.state.streetViewPanorama !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.streetViewPanorama)
     }
   }
 

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
@@ -23,10 +23,8 @@ export class StreetViewService extends React.PureComponent<
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setStreetViewServiceCallback = () => {
-    if (this.state.streetViewService !== null) {
-      if (this.props.onLoad) {
-        this.props.onLoad(this.state.streetViewService)
-      }
+    if (this.state.streetViewService !== null && this.props.onLoad) {
+      this.props.onLoad(this.state.streetViewService)
     }
   }
 

--- a/packages/react-google-maps-api/src/docs/googleMapKey.ts
+++ b/packages/react-google-maps-api/src/docs/googleMapKey.ts
@@ -1,1 +1,2 @@
-export default null
+//eslint-disable-next-line
+export default "AIzaSyC2C8wxa2nINcPvOOFwPWkyBjiHK_2NekM"

--- a/packages/react-google-maps-api/src/utils/helper.ts
+++ b/packages/react-google-maps-api/src/utils/helper.ts
@@ -38,6 +38,9 @@ export function registerEvents(
       onEventName: any
     ): google.maps.MapsEventListener[] {
       if (typeof props[onEventName] === "function") {
+        // if (onEventName === "onPolygonComplete") {
+        //   debugger
+        // }
         acc.push(
           google.maps.event.addListener(
             instance,


### PR DESCRIPTION
# Please explain PR reason.

setState callback is called after componentDidUpdate. In CDU we register event handlers, but in setState callback we don't clean them up. This causes event handlers to be registered twice, thus firing twice. 

Since CDU will always run before the setState callback, there's no need to register events in the callback.

We should probably even go a step further and initialise the state in the constructor. Any side effects should be moved to CDU. This will prepare us for moving to using hooks..