### PR TITLE
React types as a peer dependency

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -79,11 +79,11 @@
     "@react-google-maps/marker-clusterer": "1.2.0",
     "@types/googlemaps": "3.30.19",
     "@types/invariant": "2.2.29",
-    "@types/react": "16.8.10",
-    "@types/react-dom": "16.8.3",
     "invariant": "2.2.4"
   },
   "peerDependencies": {
+    "@types/react": "^16.8.10",
+    "@types/react-dom": "^16.8.3",
     "react": "^16.6.3",
     "react-dom": "^16.6.3"
   },
@@ -91,6 +91,8 @@
     "@getify/eslint-plugin-proper-arrows": "7.1.0",
     "@types/babel-types": "7.0.6",
     "@types/jest": "^24.0.11",
+    "@types/react": "^16.8.10",
+    "@types/react-dom": "^16.8.3",
     "@typescript-eslint/eslint-plugin": "1.5.0",
     "@typescript-eslint/parser": "1.5.0",
     "acorn": "6.1.1",


### PR DESCRIPTION
This is a totally bad idea to rely on a specific version of React types. In a moment you have two separate versions in a project, things get really wonky and those types are conflicting with each other.

I would generally say that any @types does not belong to package dependencies, but google maps related ones are ok because you don't usually have those installed for any other reason. The one for `invariant` shouldn't be there also imo because it's not a part of public API.