### PR TITLE
Export props interfaces

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -68,7 +68,7 @@ interface GoogleMapState {
   map: google.maps.Map | null;
 }
 
-interface GoogleMapProps {
+export interface GoogleMapProps {
   id?: string;
   reuseSameInstance?: boolean;
   mapContainerStyle?: React.CSSProperties;

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -11,7 +11,7 @@ interface LoadScriptState {
   loaded: boolean;
 }
 
-interface LoadScriptProps {
+export interface LoadScriptProps {
   // required
   id: string;
 

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
@@ -90,7 +90,7 @@ interface ClustererState {
   markerClusterer: Clusterer | null;
 }
 
-interface ClustererProps {
+export interface ClustererProps {
   // required
   children: (markerClusterer: Clusterer) => React.ReactNode;
   options?: ClustererOptions; // TODO: it could be undefined

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
@@ -39,7 +39,7 @@ interface DirectionsRendererState {
   directionsRenderer: google.maps.DirectionsRenderer | null;
 }
 
-interface DirectionsRendererProps {
+export interface DirectionsRendererProps {
   options?: google.maps.DirectionsRendererOptions;
   directions?: google.maps.DirectionsResult;
   panel?: Element;

--- a/packages/react-google-maps-api/src/components/directions/DirectionsService.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsService.tsx
@@ -6,7 +6,7 @@ interface DirectionsServiceState {
   directionsService: google.maps.DirectionsService | null;
 }
 
-interface DirectionsServiceProps {
+export interface DirectionsServiceProps {
   // required for default functionality
   options: google.maps.DirectionsRequest;
 

--- a/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
@@ -12,7 +12,7 @@ interface OverlayViewState {
   overlayView: google.maps.OverlayView | null;
 }
 
-interface OverlayViewProps {
+export interface OverlayViewProps {
   // required
   mapPaneName: string;
   getPixelPositionOffset?: (

--- a/packages/react-google-maps-api/src/components/drawing/Data.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Data.tsx
@@ -101,7 +101,7 @@ const updaterMap = {
 interface DataState {
   data: google.maps.Data | null;
 }
-interface DataProps {
+export interface DataProps {
   options?: google.maps.Data.DataOptions;
   onAddFeature?: (e: google.maps.Data.AddFeatureEvent) => void;
   onClick?: (e: google.maps.MouseEvent) => void;

--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
@@ -38,7 +38,7 @@ interface DrawingManagerState {
   drawingManager: google.maps.drawing.DrawingManager | null;
 }
 
-interface DrawingManagerProps {
+export interface DrawingManagerProps {
   options?: google.maps.drawing.DrawingManagerOptions;
   drawingMode?: google.maps.drawing.OverlayType | null;
   onCircleComplete?: (circle: google.maps.Circle) => void;

--- a/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
@@ -41,7 +41,7 @@ interface InfoWindowState {
   infoWindow: google.maps.InfoWindow | null;
 }
 
-interface InfoWindowProps {
+export interface InfoWindowProps {
   anchor: google.maps.MVCObject | null;
   options?: google.maps.InfoWindowOptions;
   position: google.maps.LatLng | google.maps.LatLngLiteral;

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -88,7 +88,7 @@ interface MarkerState {
   marker: google.maps.Marker | null;
 }
 
-interface MarkerProps {
+export interface MarkerProps {
   options?: google.maps.MapOptions;
   animation?: google.maps.Animation;
   clickable?: boolean;

--- a/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
@@ -58,7 +58,7 @@ interface PolygonState {
   polygon: google.maps.Polygon | null;
 }
 
-interface PolygonProps {
+export interface PolygonProps {
   options?: google.maps.PolygonOptions;
   draggable?: boolean;
   editable?: boolean;

--- a/packages/react-google-maps-api/src/components/drawing/Polyline.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polyline.tsx
@@ -52,7 +52,7 @@ interface PolylineState {
   polyline: google.maps.Polyline | null;
 }
 
-interface PolylineProps {
+export interface PolylineProps {
   options?: google.maps.PolylineOptions;
   draggable?: boolean;
   editable?: boolean;

--- a/packages/react-google-maps-api/src/components/drawing/Rectangle.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Rectangle.tsx
@@ -52,7 +52,7 @@ interface RectangleState {
   rectangle: google.maps.Rectangle | null;
 }
 
-interface RectangleProps {
+export interface RectangleProps {
   options?: google.maps.RectangleOptions;
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
   draggable?: boolean;

--- a/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.tsx
+++ b/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.tsx
@@ -34,7 +34,7 @@ interface HeatmapLayerState {
   heatmapLayer: google.maps.visualization.HeatmapLayer | null;
 }
 
-interface HeatmapLayerProps {
+export interface HeatmapLayerProps {
   // required
   data: google.maps.MVCArray<google.maps.LatLng | google.maps.visualization.WeightedLocation> | google.maps.LatLng[] | google.maps.visualization.WeightedLocation[];
   options?: google.maps.visualization.HeatmapLayerOptions;

--- a/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
+++ b/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
@@ -32,7 +32,7 @@ interface KmlLayerState {
   kmlLayer: google.maps.KmlLayer | null;
 }
 
-interface KmlLayerProps {
+export interface KmlLayerProps {
   options?: google.maps.KmlLayerOptions;
   url?: string;
   zIndex?: number;

--- a/packages/react-google-maps-api/src/components/maps/BicyclingLayer.tsx
+++ b/packages/react-google-maps-api/src/components/maps/BicyclingLayer.tsx
@@ -6,7 +6,7 @@ interface BicyclingLayerState {
   bicyclingLayer: google.maps.BicyclingLayer | null;
 }
 
-interface BicyclingLayerProps {
+export interface BicyclingLayerProps {
   onLoad?: (bicyclingLayer: google.maps.BicyclingLayer) => void;
   onUnmount?: (bicyclingLayer: google.maps.BicyclingLayer) => void;
 }
@@ -27,7 +27,7 @@ export class BicyclingLayer extends React.PureComponent<
       // TODO: how is this possibly null if we're doing a null check
       // @ts-ignore
       this.state.bicyclingLayer.setMap(this.context)
-      
+
       if (this.props.onLoad) {
         //@ts-ignore
         this.props.onLoad(this.state.bicyclingLayer)

--- a/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
+++ b/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
@@ -21,7 +21,7 @@ interface TrafficLayerState {
   trafficLayer: google.maps.TrafficLayer | null;
 }
 
-interface TrafficLayerProps {
+export interface TrafficLayerProps {
   options?: google.maps.TrafficLayerOptions;
   onLoad?: (trafficLayer: google.maps.TrafficLayer) => void;
   onUnmount?: (trafficLayer: google.maps.TrafficLayer) => void;
@@ -54,7 +54,7 @@ export class TrafficLayer extends PureComponent<
       ...(this.props.options || {}),
       map: this.context
     })
-    
+
     this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
       updaterMap,
       eventMap,

--- a/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
+++ b/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
@@ -24,7 +24,7 @@ interface GroundOverlayState {
   groundOverlay: google.maps.GroundOverlay | null;
 }
 
-interface GroundOverlayProps {
+export interface GroundOverlayProps {
   options?: google.maps.GroundOverlayOptions;
   opacity?: number;
   onDblClick?: (e: google.maps.MouseEvent) => void;

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -48,7 +48,7 @@ interface AutocompleteState {
   autocomplete: google.maps.places.Autocomplete | null;
 }
 
-interface AutocompleteProps {
+export interface AutocompleteProps {
   // required
   children: React.ReactChild;
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
@@ -26,7 +26,7 @@ interface StandaloneSearchBoxState {
   searchBox: google.maps.places.SearchBox | null;
 }
 
-interface StandaloneSearchBoxProps {
+export interface StandaloneSearchBoxProps {
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral;
   options?: google.maps.places.SearchBoxOptions;
   onPlacesChanged?: () => void;

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
@@ -73,7 +73,7 @@ interface StreetViewPanoramaState {
   streetViewPanorama: google.maps.StreetViewPanorama | null;
 }
 
-interface StreetViewPanoramaProps {
+export interface StreetViewPanoramaProps {
   options?: google.maps.StreetViewPanoramaOptions;
   onCloseclick?: (event: google.maps.event) => void;
   onPanoChanged?: () => void;

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import MapContext from "../../map-context"
 
-interface StreetViewServiceProps {
+export interface StreetViewServiceProps {
   onLoad?: (streetViewService: google.maps.StreetViewService | null) => void;
   onUnmount?: (streetViewService: google.maps.StreetViewService | null) => void;
 }

--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -1,41 +1,52 @@
-export { default as GoogleMap } from "./GoogleMap"
-export { default as LoadScript } from "./LoadScript"
-export { default as TrafficLayer } from "./components/maps/TrafficLayer"
-export { default as BicyclingLayer } from "./components/maps/BicyclingLayer"
-
-export { default as DrawingManager } from "./components/drawing/DrawingManager"
-export { default as Marker } from "./components/drawing/Marker"
-export { default as MarkerClusterer } from "./components/addons/MarkerClusterer"
-
-export { default as InfoWindow } from "./components/drawing/InfoWindow"
-export { default as Polyline } from "./components/drawing/Polyline"
-export { default as Polygon } from "./components/drawing/Polygon"
-export { default as Rectangle } from "./components/drawing/Rectangle"
-export { default as Circle } from "./components/drawing/Circle"
-export { default as Data } from "./components/drawing/Data"
-
-export { default as KmlLayer } from "./components/kml/KmlLayer"
-
-export { default as OverlayView } from "./components/dom/OverlayView"
-
-export { default as GroundOverlay } from "./components/overlays/GroundOverlay"
-export { default as HeatmapLayer } from "./components/heatmap/HeatmapLayer"
+export { default as GoogleMap, GoogleMapProps } from "./GoogleMap";
+export { default as LoadScript, LoadScriptProps } from "./LoadScript";
+export { default as TrafficLayer, TrafficLayerProps } from "./components/maps/TrafficLayer";
+export { default as BicyclingLayer, BicyclingLayerProps } from "./components/maps/BicyclingLayer";
 
 export {
-  default as StreetViewPanorama
-} from "./components/streetview/StreetViewPanorama"
+  default as DrawingManager,
+  DrawingManagerProps
+} from "./components/drawing/DrawingManager";
+export { default as Marker, MarkerProps } from "./components/drawing/Marker";
 export {
-  default as StreetViewService
-} from "./components/streetview/StreetViewService"
+  default as MarkerClusterer,
+  ClustererProps as MarkerClustererProps
+} from "./components/addons/MarkerClusterer";
+
+export { default as InfoWindow, InfoWindowProps } from "./components/drawing/InfoWindow";
+export { default as Polyline, PolylineProps } from "./components/drawing/Polyline";
+export { default as Polygon, PolygonProps } from "./components/drawing/Polygon";
+export { default as Rectangle, RectangleProps } from "./components/drawing/Rectangle";
+export { default as Circle, CircleProps } from "./components/drawing/Circle";
+export { default as Data, DataProps } from "./components/drawing/Data";
+
+export { default as KmlLayer, KmlLayerProps } from "./components/kml/KmlLayer";
+
+export { default as OverlayView, OverlayViewProps } from "./components/dom/OverlayView";
+
+export { default as GroundOverlay, GroundOverlayProps } from "./components/overlays/GroundOverlay";
+export { default as HeatmapLayer, HeatmapLayerProps } from "./components/heatmap/HeatmapLayer";
 
 export {
-  default as DirectionsService
-} from "./components/directions/DirectionsService"
+  default as StreetViewPanorama,
+  StreetViewPanoramaProps
+} from "./components/streetview/StreetViewPanorama";
 export {
-  default as DirectionsRenderer
-} from "./components/directions/DirectionsRenderer"
+  default as StreetViewService,
+  StreetViewServiceProps
+} from "./components/streetview/StreetViewService";
 
 export {
-  default as StandaloneSearchBox
-} from "./components/places/StandaloneSearchBox"
-export { default as Autocomplete } from "./components/places/Autocomplete"
+  default as DirectionsService,
+  DirectionsServiceProps
+} from "./components/directions/DirectionsService";
+export {
+  default as DirectionsRenderer,
+  DirectionsRendererProps
+} from "./components/directions/DirectionsRenderer";
+
+export {
+  default as StandaloneSearchBox,
+  StandaloneSearchBoxProps
+} from "./components/places/StandaloneSearchBox";
+export { default as Autocomplete, AutocompleteProps } from "./components/places/Autocomplete";


### PR DESCRIPTION
This is super useful for any sort of wrapping. Simplified example...

```tsx
interface IProps extends GoogleMapProps {
  model: TMapModel
}

const BaseMap: React.FC<IProps> = ({ model, ...mapProps }) => {
  <LoadScript ...>
    <GoogleMap {...model.mapProps} {...mapProps}>{children}</GoogleMap>
  </LoadScript>
}
```