### PR TITLE
fix(api): Redraw OverlayView on position or bounds change

### DIFF
--- a/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
@@ -140,6 +140,12 @@ export class OverlayView extends React.PureComponent<
 
     this.setState(setOverlayView, this.setOverlayViewCallback)
   }
+  
+  componentDidUpdate(prevProps: OverlayViewProps) {
+    if (prevProps.position !== this.props.position || prevProps.bounds !== this.props.bounds) {
+      setTimeout(() => this.state.overlayView!.draw(), 0);
+    }
+  }
 
   componentWillUnmount() {
     if (this.state.overlayView !== null) {


### PR DESCRIPTION
https://spectrum.chat/react-google-maps/general/overlayview-position-is-not-updated~3a32f12a-b909-4316-af7a-cd6f9a92ed8c

Unfortunately, I was not able to test it out, build is failing for me with bunch of TS errors.