### PR TITLE
[OverlayView] Add check for containerElement

### DIFF
--- a/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
@@ -103,7 +103,9 @@ export class OverlayView extends React.PureComponent<
       return
     }
 
-    mapPanes[this.props.mapPaneName].appendChild(this.containerElement)
+    if (this.containerElement) {
+      mapPanes[this.props.mapPaneName].appendChild(this.containerElement)
+    }
 
     this.onPositionElement()
 


### PR DESCRIPTION
As much as awkward this looks, it seems that on some occasion the `draw` is called before the `onAdd` causing the error. It seems to be able to recover itself with a next draw, but it's kinda spamming our bug reporting service.

> Failed to execute 'appendChild' on 'Node': parameter 1 is not of type 'Node'

![image](https://user-images.githubusercontent.com/1096340/57402154-f6427000-71d6-11e9-83e8-59e7f4768f34.png)
