### PR TITLE
Added two new mouse Events to help on mobile devices

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -15,6 +15,8 @@ const eventMap = {
   onMouseMove: "mousemove",
   onMouseOut: "mouseout",
   onMouseOver: "mouseover",
+  onMouseDown: "mousedown",
+  onMouseUp: "mouseup",
   onRightClick: "rightclick",
   onTilesLoaded: "tilesloaded",
   onBoundsChanged: "bounds_changed",


### PR DESCRIPTION
Added 2 new event from the native events list of Google maps.
Those 2 new events add the opportunity to the user to listen at the mouse down and mouse up events.
Can help to create a method to manage long click on mobile devices.