### PR TITLE
Add useLoadScript and LoadScriptNext

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -5,6 +5,7 @@ import { preventGoogleFonts } from "./utils/prevent-google-fonts"
 
 import { isBrowser } from "./utils/isbrowser"
 import { LoadScriptUrlOptions, makeLoadScriptUrl } from "./utils/make-load-script-url";
+import invariant from "invariant";
 
 let cleaningUp = false
 
@@ -13,6 +14,7 @@ interface LoadScriptState {
 }
 
 export interface LoadScriptProps extends LoadScriptUrlOptions {
+  id?: string;
   loadingElement?: React.ReactNode;
   onLoad?: () => void;
   onError?: (error: Error) => void;
@@ -173,6 +175,8 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
     if (this.props.preventGoogleFontsLoading) {
       preventGoogleFonts()
     }
+
+    invariant(typeof this.props.id === 'string', 'LoadScript requires "id" prop to be a string')
 
     const injectScriptOptions = {
       id: this.props.id!,

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -165,7 +165,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
     Array.prototype.slice
       .call(document.getElementsByTagName("style"))
       .filter(function filter(style: HTMLStyleElement): boolean {
-        return style.innerText && style.innerText.includes(".gm-")
+        return style.innerText.length > 0 && style.innerText.includes(".gm-")
       })
       .forEach(function forEach(style: HTMLStyleElement) {
         if (style.parentNode) {

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -26,15 +26,17 @@ export interface LoadScriptProps {
   preventGoogleFontsLoading?: boolean;
 }
 
-const DefaultLoadingElement = () => (
-  <div>{`Loading...`}</div>
-)
+export function DefaultLoadingElement() {
+  return <div>{`Loading...`}</div>
+}
+
+export const defaultLoadScriptProps = {
+  id: 'script-loader',
+  version: 'weekly'
+}
 
 class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
-  public static defaultProps = {
-    id: 'script-loader',
-    version: 'weekly',
-  }
+  public static defaultProps = defaultLoadScriptProps
 
   check: React.RefObject<HTMLDivElement> = React.createRef()
 
@@ -108,7 +110,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
   // eslint-disable-next-line @getify/proper-arrows/name
   isCleaningUp = async () => {
-    function promiseCallback (resolve: () => void) {
+    function promiseCallback(resolve: () => void) {
       if (!cleaningUp) {
         resolve()
       } else {
@@ -140,10 +142,10 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("script"))
-      .filter(function filter (script: HTMLScriptElement) {
+      .filter(function filter(script: HTMLScriptElement) {
         return script.src.includes("maps.googleapis")
       })
-      .forEach(function forEach (script: HTMLScriptElement) {
+      .forEach(function forEach(script: HTMLScriptElement) {
         if (script.parentNode) {
           script.parentNode.removeChild(script)
         }
@@ -151,11 +153,11 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("link"))
-      .filter(function filter (link: HTMLLinkElement) {
+      .filter(function filter(link: HTMLLinkElement) {
         link.href ===
-        "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Google+Sans"
+          "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Google+Sans"
       })
-      .forEach(function forEach (link: HTMLLinkElement) {
+      .forEach(function forEach(link: HTMLLinkElement) {
         if (link.parentNode) {
           link.parentNode.removeChild(link)
         }
@@ -163,10 +165,10 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("style"))
-      .filter(function filter (style: HTMLStyleElement) {
+      .filter(function filter(style: HTMLStyleElement) {
         return style.innerText && style.innerText.includes(".gm-")
       })
-      .forEach(function forEach (style: HTMLStyleElement) {
+      .forEach(function forEach(style: HTMLStyleElement) {
         if (style.parentNode) {
           style.parentNode.removeChild(style)
         }
@@ -209,7 +211,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
           this.props.onLoad()
         }
 
-        this.setState(function setLoaded () {
+        this.setState(function setLoaded() {
           return {
             loaded: true
           }

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -142,10 +142,10 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("script"))
-      .filter(function filter(script: HTMLScriptElement) {
+      .filter(function filter(script: HTMLScriptElement): boolean {
         return script.src.includes("maps.googleapis")
       })
-      .forEach(function forEach(script: HTMLScriptElement) {
+      .forEach(function forEach(script: HTMLScriptElement): void {
         if (script.parentNode) {
           script.parentNode.removeChild(script)
         }
@@ -153,9 +153,8 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("link"))
-      .filter(function filter(link: HTMLLinkElement) {
-        link.href ===
-          "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Google+Sans"
+      .filter(function filter(link: HTMLLinkElement): boolean {
+        return link.href === "https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Google+Sans"
       })
       .forEach(function forEach(link: HTMLLinkElement) {
         if (link.parentNode) {
@@ -165,7 +164,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     Array.prototype.slice
       .call(document.getElementsByTagName("style"))
-      .filter(function filter(style: HTMLStyleElement) {
+      .filter(function filter(style: HTMLStyleElement): boolean {
         return style.innerText && style.innerText.includes(".gm-")
       })
       .forEach(function forEach(style: HTMLStyleElement) {

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -4,7 +4,7 @@ import { injectScript } from "./utils/injectscript"
 import { preventGoogleFonts } from "./utils/prevent-google-fonts"
 
 import { isBrowser } from "./utils/isbrowser"
-import invariant from "invariant";
+import { LoadScriptUrlOptions, makeLoadScriptUrl } from "./utils/make-load-script-url";
 
 let cleaningUp = false
 
@@ -12,14 +12,7 @@ interface LoadScriptState {
   loaded: boolean;
 }
 
-export interface LoadScriptProps {
-  googleMapsApiKey?: string;
-  googleMapsClientId?: string;
-  id?: string;
-  version?: string;
-  language?: string;
-  region?: string;
-  libraries?: string[];
+export interface LoadScriptProps extends LoadScriptUrlOptions {
   loadingElement?: React.ReactNode;
   onLoad?: () => void;
   onError?: (error: Error) => void;
@@ -177,41 +170,13 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   injectScript = () => {
-    const { googleMapsApiKey, googleMapsClientId, id, version, language, region, libraries, preventGoogleFontsLoading } = this.props
-
-    if (preventGoogleFontsLoading) {
+    if (this.props.preventGoogleFontsLoading) {
       preventGoogleFonts()
     }
 
-    const params = []
-
-    if (googleMapsApiKey) {
-      params.push(`key=${googleMapsApiKey}`)
-    } else if (googleMapsClientId) {
-      params.push(`client=${googleMapsClientId}`)
-    } else {
-      invariant(false, "You need to specify either googleMapsApiKey or googleMapsClientId for @react-google-maps/api load script to work.")
-    }
-
-    if (version) {
-      params.push(`v=${version}`)
-    }
-
-    if (language) {
-      params.push(`language=${language}`)
-    }
-
-    if (region) {
-      params.push(`region=${region}`)
-    }
-
-    if (libraries && libraries.length) {
-      params.push(`&libraries=${libraries.join(",")}`)
-    }
-
     const injectScriptOptions = {
-      id: id!,
-      url: `https://maps.googleapis.com/maps/api/js?${params.join('&')}`
+      id: this.props.id!,
+      url: makeLoadScriptUrl(this.props)
     }
 
     injectScript(injectScriptOptions)
@@ -234,7 +199,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
         }
 
         console.error(`
-          There has been an Error with loading Google Maps API script, please check that you provided correct google API key (${googleMapsApiKey || '-'}) or Client ID (${googleMapsClientId || '-'}) to <LoadScript />
+          There has been an Error with loading Google Maps API script, please check that you provided correct google API key (${this.props.googleMapsApiKey || '-'}) or Client ID (${this.props.googleMapsClientId || '-'}) to <LoadScript />
           Otherwise it is a Network issue.
         `)
       })

--- a/packages/react-google-maps-api/src/LoadScriptNext.md
+++ b/packages/react-google-maps-api/src/LoadScriptNext.md
@@ -1,0 +1,3 @@
+### Requires React 16.8+
+
+Utilizes [useLoadScript](#useloadscript) hook and additionally allows to specify `onLoad`, `onError` and `onUnmount` callbacks along with `loadingElement` for ease of use.

--- a/packages/react-google-maps-api/src/LoadScriptNext.tsx
+++ b/packages/react-google-maps-api/src/LoadScriptNext.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+
+import { DefaultLoadingElement } from './LoadScript'
+import { useLoadScript, UseLoadScriptOptions } from './useLoadScript'
+
+export interface LoadScriptNextProps extends UseLoadScriptOptions {
+  loadingElement?: React.ReactElement
+  onLoad?: () => void;
+  onError?: (error: Error) => void;
+  onUnmount?: () => void;
+  children: React.ReactElement
+}
+
+const defaultLoadingElement = <DefaultLoadingElement />
+
+function LoadScriptNext({ loadingElement, onLoad, onError, onUnmount, children, ...hookOptions }: LoadScriptNextProps) {
+  const { isLoaded, loadError } = useLoadScript(hookOptions)
+
+  React.useEffect(function handleOnLoad() {
+    if (isLoaded && typeof onLoad === "function") {
+      onLoad()
+    }
+  }, [isLoaded, onLoad])
+
+  React.useEffect(function handleOnError() {
+    if (loadError && typeof onError === "function") {
+      onError(loadError)
+    }
+  }, [loadError, onError])
+
+  React.useEffect(function handleOnUnmount() {
+    return () => {
+      if (onUnmount) {
+        onUnmount()
+      }
+    }
+  }, [onUnmount])
+
+  return isLoaded ? children : loadingElement || defaultLoadingElement
+}
+
+export default React.memo(LoadScriptNext)

--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -9,6 +9,15 @@ export {
 } from "./LoadScript"
 
 export {
+  default as LoadScriptNext,
+  LoadScriptNextProps
+} from "./LoadScriptNext"
+
+export {
+  useLoadScript
+} from './useLoadScript'
+
+export {
   default as TrafficLayer,
   TrafficLayerProps
 } from "./components/maps/TrafficLayer"

--- a/packages/react-google-maps-api/src/useGoogleMap.md
+++ b/packages/react-google-maps-api/src/useGoogleMap.md
@@ -1,0 +1,16 @@
+# Access google map instance
+
+```js static
+import React from 'react'
+import { GoogleMap, useGoogleMap } from '@react-google-maps/api'
+
+function PanningComponent() {
+  const map = useGoogleMap()
+
+  React.useEffect(() => {
+    map.panTo(...)
+  }, [map])
+
+  return null
+}
+```

--- a/packages/react-google-maps-api/src/useLoadScript.md
+++ b/packages/react-google-maps-api/src/useLoadScript.md
@@ -1,0 +1,39 @@
+### Requires React 16.8+
+
+Underlying React hook that can be used for a fine-grained approach instead of opinionated [LoadScriptNext](#loadscriptnext).
+
+It's the alternative variant of LoadScript that tries to solve the problem of "google is not defined" error by removing the cleanup routines ([read more](https://github.com/JustFly1984/react-google-maps-api/pull/143)).
+
+```js static
+import React from 'react'
+import { GoogleMap, useLoadScript } from '@react-google-maps/api'
+
+function MyComponent() {
+  const { isLoaded, loadError } = useLoadScript({
+    googleMapsApiKey="YOUR_API_KEY"
+    {...other options}
+  })
+
+  const renderMap = () => {
+    // wrapping to a function is useful in case you want to access `window.google`
+    // to eg. setup options or create latLng object, it won't be available otherwise
+    // feel free to render directly if you don't need that
+    return <GoogleMap
+      options={{
+        zoomControlOptions: {
+          position: google.maps.ControlPosition.RIGHT_CENTER
+        }
+      }}
+      {...other props }
+    >
+      ...Your map components
+    </GoogleMap>
+  }
+
+  if (loadError) {
+    return <div>Map cannot be loaded right now, sorry.</div>
+  }
+
+  return isLoaded ? renderMap() : <Spinner />
+}
+```

--- a/packages/react-google-maps-api/src/useLoadScript.ts
+++ b/packages/react-google-maps-api/src/useLoadScript.ts
@@ -1,0 +1,114 @@
+import * as React from 'react'
+
+import { injectScript } from './utils/injectscript'
+import { preventGoogleFonts } from './utils/prevent-google-fonts'
+
+import { isBrowser } from './utils/isbrowser'
+import { defaultLoadScriptProps } from './LoadScript'
+
+export interface UseLoadScriptOptions {
+  // required
+  googleMapsApiKey: string;
+  id?: string;
+  version?: string;
+  language?: string;
+  region?: string;
+  libraries?: string[];
+  preventGoogleFontsLoading?: boolean;
+}
+
+export function useLoadScript({
+  id = defaultLoadScriptProps.id,
+  version = defaultLoadScriptProps.version,
+  googleMapsApiKey,
+  language,
+  region,
+  libraries,
+  preventGoogleFontsLoading,
+}: UseLoadScriptOptions) {
+  const isMounted = React.useRef(false)
+  const [isLoaded, setLoaded] = React.useState(false)
+  const [loadError, setLoadError] = React.useState<Error | undefined>(undefined)
+
+  React.useEffect(function trackMountedState() {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  React.useEffect(function applyPreventGoogleFonts() {
+    if (isBrowser && preventGoogleFontsLoading) {
+      preventGoogleFonts()
+    }
+  }, [preventGoogleFontsLoading])
+
+  const url = makeUrl()
+
+  React.useEffect(function loadScriptAndModifyLoadedState() {
+    if (!isBrowser) {
+      return
+    }
+
+    function setLoadedIfMounted() {
+      if (isMounted.current) {
+        setLoaded(true)
+      }
+    }
+
+    // @ts-ignore
+    if (window.google) {
+      console.error('google api is already presented')
+      setLoadedIfMounted()
+      return
+    }
+
+    injectScript({ id, url })
+      .then(setLoadedIfMounted)
+      .catch(function handleInjectError(err) {
+        if (isMounted.current) {
+          setLoadError(err)
+        }
+        console.warn(`
+        There has been an Error with loading Google Maps API script, please check that you provided correct google API key to <LoadScript /> (${googleMapsApiKey})
+        Otherwise it is a Network issues.
+      `)
+        console.error(err)
+      })
+  }, [id, url])
+
+  const prevLibraries = React.useRef<undefined | string[]>()
+
+  React.useEffect(function checkPerformance() {
+    if (prevLibraries.current && libraries !== prevLibraries.current) {
+      console.warn(
+        'Performance warning! Loadscript has been reloaded unintentionally! You should not pass `libraries` prop as new array. Please keep an array of libraries as static class property for Components and PureComponents, or just a const variable outside of component, or somewhere in config files or ENV variables'
+      )
+    }
+    prevLibraries.current = libraries
+  }, [libraries])
+
+  function makeUrl() {
+    const params = [`key=${googleMapsApiKey}`]
+
+    if (version) {
+      params.push(`v=${version}`)
+    }
+
+    if (language) {
+      params.push(`language=${language}`)
+    }
+
+    if (region) {
+      params.push(`region=${region}`)
+    }
+
+    if (libraries && libraries.length) {
+      params.push(`libraries=${libraries.join(',')}`)
+    }
+
+    return `https://maps.googleapis.com/maps/api/js?${params.join('&')}`
+  }
+
+  return { isLoaded, loadError, url }
+}

--- a/packages/react-google-maps-api/src/useLoadScript.ts
+++ b/packages/react-google-maps-api/src/useLoadScript.ts
@@ -5,10 +5,11 @@ import { preventGoogleFonts } from './utils/prevent-google-fonts'
 
 import { isBrowser } from './utils/isbrowser'
 import { defaultLoadScriptProps } from './LoadScript'
+import invariant from 'invariant';
 
 export interface UseLoadScriptOptions {
-  // required
-  googleMapsApiKey: string;
+  googleMapsApiKey?: string;
+  googleMapsClientId?: string;
   id?: string;
   version?: string;
   language?: string;
@@ -21,6 +22,7 @@ export function useLoadScript({
   id = defaultLoadScriptProps.id,
   version = defaultLoadScriptProps.version,
   googleMapsApiKey,
+  googleMapsClientId,
   language,
   region,
   libraries,
@@ -70,8 +72,8 @@ export function useLoadScript({
           setLoadError(err)
         }
         console.warn(`
-        There has been an Error with loading Google Maps API script, please check that you provided correct google API key to <LoadScript /> (${googleMapsApiKey})
-        Otherwise it is a Network issues.
+        There has been an Error with loading Google Maps API script, please check that you provided correct google API key (${googleMapsApiKey || '-'}) or Client ID (${googleMapsClientId || '-'})
+        Otherwise it is a Network issue.
       `)
         console.error(err)
       })
@@ -89,7 +91,15 @@ export function useLoadScript({
   }, [libraries])
 
   function makeUrl() {
-    const params = [`key=${googleMapsApiKey}`]
+    const params = []
+
+    if (googleMapsApiKey) {
+      params.push(`key=${googleMapsApiKey}`)
+    } else if (googleMapsClientId) {
+      params.push(`client=${googleMapsClientId}`)
+    } else {
+      invariant(false, "You need to specify either googleMapsApiKey or googleMapsClientId for @react-google-maps/api load script to work.")
+    }
 
     if (version) {
       params.push(`v=${version}`)

--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -6,16 +6,10 @@ import { preventGoogleFonts } from './utils/prevent-google-fonts'
 import { isBrowser } from './utils/isbrowser'
 import { defaultLoadScriptProps } from './LoadScript'
 import invariant from 'invariant';
-import { makeLoadScriptUrl } from './utils/make-load-script-url';
+import { makeLoadScriptUrl, LoadScriptUrlOptions } from './utils/make-load-script-url';
 
-export interface UseLoadScriptOptions {
-  googleMapsApiKey?: string;
-  googleMapsClientId?: string;
-  id?: string;
-  version?: string;
-  language?: string;
-  region?: string;
-  libraries?: string[];
+export interface UseLoadScriptOptions extends LoadScriptUrlOptions {
+  id?: string
   preventGoogleFontsLoading?: boolean;
 }
 
@@ -23,7 +17,7 @@ let previouslyLoadedUrl: string
 
 export function useLoadScript({
   id = defaultLoadScriptProps.id,
-  version,
+  version = defaultLoadScriptProps.version,
   googleMapsApiKey,
   googleMapsClientId,
   language,

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -3,7 +3,6 @@ import invariant from "invariant";
 export interface LoadScriptUrlOptions {
   googleMapsApiKey?: string;
   googleMapsClientId?: string;
-  id?: string;
   version?: string;
   language?: string;
   region?: string;

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -1,0 +1,51 @@
+import invariant from "invariant";
+
+export interface LoadScriptUrlOptions {
+  googleMapsApiKey?: string;
+  googleMapsClientId?: string;
+  id?: string;
+  version?: string;
+  language?: string;
+  region?: string;
+  libraries?: string[];
+}
+
+export function makeLoadScriptUrl({
+  googleMapsApiKey,
+  googleMapsClientId,
+  version = 'weekly',
+  language,
+  region,
+  libraries
+}: LoadScriptUrlOptions) {
+  const params = []
+
+  invariant(
+    (googleMapsApiKey && googleMapsClientId) || !(googleMapsApiKey && googleMapsClientId),
+    "You need to specify either googleMapsApiKey or googleMapsClientId for @react-google-maps/api load script to work. You cannot use both at the same time."
+  )
+
+  if (googleMapsApiKey) {
+    params.push(`key=${googleMapsApiKey}`)
+  } else if (googleMapsClientId) {
+    params.push(`client=${googleMapsClientId}`)
+  }
+
+  if (version) {
+    params.push(`v=${version}`)
+  }
+
+  if (language) {
+    params.push(`language=${language}`)
+  }
+
+  if (region) {
+    params.push(`region=${region}`)
+  }
+
+  if (libraries && libraries.length) {
+    params.push(`libraries=${libraries.join(",")}`)
+  }
+
+  return `https://maps.googleapis.com/maps/api/js?${params.join('&')}`
+}

--- a/packages/react-google-maps-api/styleguide.config.js
+++ b/packages/react-google-maps-api/styleguide.config.js
@@ -34,7 +34,10 @@ module.exports = {
       name: "Components",
       components: [
         "src/LoadScript.tsx",
+        "src/LoadScriptNext.tsx",
+        "src/useLoadScript.tsx",
         "src/GoogleMap.tsx",
+        "src/map-context.tsx",
         "src/components/**/*.tsx"
       ]
     }

--- a/packages/react-google-maps-api/styleguide.config.js
+++ b/packages/react-google-maps-api/styleguide.config.js
@@ -37,7 +37,6 @@ module.exports = {
         "src/LoadScriptNext.tsx",
         "src/useLoadScript.tsx",
         "src/GoogleMap.tsx",
-        "src/map-context.tsx",
         "src/components/**/*.tsx"
       ]
     }


### PR DESCRIPTION
Fixes #139 

As noted in #139, instead of modifying current LoadScript I have created an alternative approach with Hooks and without that cleanup logic which I think was causing more issues than it helped.

I've added this build into our app and so far it works correctly and intend to push it to the production soon (yes, I am that bold) so we will see if it actually helps.

I've also decided to keep whole logic in the `useLoadScript` hook instead of a component to provide loading state directly instead of the callback. This is the way I am using it and works great. 

```tsx
export const BaseMap = observer<IBaseMapProps>(
  ({ model, children }) => {
    const { user } = useRoot()

    const { isLoaded } = useLoadScript({
      id: 'script-loader',
      version: 'weekly',
      googleMapsApiKey: appConfig.googleMapsApi!,
      libraries,
      language: user.language,
    })

    const renderMap = () => (
      <GoogleMap
        zoom={model.zoom}
        center={model.center}
        onCenterChanged={model.updatePosition}
        onZoomChanged={model.updateZoom}
        onClick={model.onClick}
        onLoad={model.setMapRef}
        onUnmount={() => model.setMapRef(null)}
        options={getMapOptions(isMobile)}
      >
        {children}
      </GoogleMap>
    )

    return isLoaded ? renderMap() : <Loading />
  },
)
```

For the convenience (and possible migration path), there is the `LoadScriptNext` component, but personally, I think it's not that useful anymore.

cc @JustFly1984 @uriklar @orta-sanz