### PR TITLE
Correct clusterer main fields

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/package.json
+++ b/packages/react-google-maps-api-marker-clusterer/package.json
@@ -21,8 +21,8 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "unpkg": "dist/reactgooglemapsmarkerclusterer.umd.production.js",
-  "module": "dist/reactgooglemapsmarkerclusterer.es.production.js",
+  "unpkg": "dist/markerclusterer.umd.production.js",
+  "module": "dist/markerclusterer.es.production.js",
   "files": [
     "src/",
     "dist/"


### PR DESCRIPTION
My mistake just noticed it ... https://unpkg.com/@react-google-maps/marker-clusterer@1.2.4