### PR TITLE
Running Gatsby locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,11 +25,14 @@
   "scripts": {
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
+    "build:api": "cd packages/react-google-maps-api && yarn build && cd ../..",
     "build:docs": "cd packages/react-google-maps-api && yarn docs:build && cd ../..",
     "build:clusterer": "cd packages/react-google-maps-api-marker-clusterer && yarn build && cd ../..",
     "build:gatsby": "cd packages/react-google-maps-api-gatsby-example && yarn build && cd ../..",
     "prebuild:docs": "yarn build:clusterer",
     "prebuild:gatsby": "yarn build:clusterer",
+    "start:gatsby": "cd packages/react-google-maps-api-gatsby-example && yarn start && cd ../..",
+    "prestart:gatsby": "yarn build:clusterer && yarn build:api",
     "clean": "rimraf ./yarn.lock ./package-lock.json ./node_modules/ && yarn",
     "lint": "lerna run lint --scope=@react-google-maps/api --stream",
     "storybook": "lerna run start --scope=@react-google-maps/storybook --stream"

--- a/packages/react-google-maps-api-gatsby-example/.eslintignore
+++ b/packages/react-google-maps-api-gatsby-example/.eslintignore
@@ -2,4 +2,5 @@
 public/
 node_modules/
 static/geo.json
-../react-google-maps-api/dist/index.js
+../react-google-maps-api/dist/*
+../react-google-maps-api-marker-clusterer/dist/*


### PR DESCRIPTION
Fixes #147 

I've also included root script `start:gatsby` that builds both dependents packages just to be sure. Since TSDX keep a cache, it shouldn't take much longer to build these repeatedly.

Eventually, some watch mode (available in TSDX) could be added if a need arise.