### PR TITLE
Improve docs

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.md
+++ b/packages/react-google-maps-api/src/GoogleMap.md
@@ -1,7 +1,7 @@
 # Google Map example
 
 ```jsx
-const { GoogleMap, LoadScript } = require("./");
+const { LoadScript } = require("./LoadScript");
 const ScriptLoaded = require("./docs/ScriptLoaded").default;
 
 <ScriptLoaded>
@@ -18,4 +18,27 @@ const ScriptLoaded = require("./docs/ScriptLoaded").default;
     }}
   />
 </ScriptLoaded>;
+```
+
+## Map instance
+
+To access map instance (eg. to pan the map imperatively), you can utilize the `onLoad` prop of GoogleMap component.
+
+The GoogleMap component uses React Context internally to pass the map instance around. For the convenience the value is exposed with hook `useGoogleMap` (**_requires React 16.8+_**).
+
+```js static
+import React from 'react'
+import { useGoogleMap } from '@react-google-maps/api'
+
+function PanningComponent() {
+  const map = useGoogleMap()
+
+  React.useEffect(() => {
+    if (map) {
+      map.panTo(...)
+    }
+  }, [map])
+
+  return null
+}
 ```

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
@@ -2,7 +2,7 @@
 
 ```jsx
 const { Component } = require('react');
-const { GoogleMap, LoadScript, DirectionsRenderer, DirectionsService } = require("../../");
+const { GoogleMap, LoadScript, DirectionsService } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 class Directions extends Component {

--- a/packages/react-google-maps-api/src/components/dom/OverlayView.md
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.md
@@ -1,7 +1,7 @@
 # OverlayView example
 
 ```jsx
-const { GoogleMap, LoadScript, OverlayView } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Circle.md
+++ b/packages/react-google-maps-api/src/components/drawing/Circle.md
@@ -1,7 +1,7 @@
 # Circle example
 
 ```jsx
-const { GoogleMap, LoadScript, Circle } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Data.md
+++ b/packages/react-google-maps-api/src/components/drawing/Data.md
@@ -1,7 +1,7 @@
 # Data example
 
 ```jsx
-const { GoogleMap, LoadScript, Data } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.md
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.md
@@ -1,7 +1,7 @@
 # DrawingManager example
 
 ```jsx
-const { GoogleMap, LoadScript, DrawingManager } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/InfoWindow.md
+++ b/packages/react-google-maps-api/src/components/drawing/InfoWindow.md
@@ -1,7 +1,7 @@
 # InfoWindow example
 
 ```jsx
-const { GoogleMap, LoadScript, InfoWindow } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Marker.md
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.md
@@ -1,7 +1,7 @@
 # Marker example
 
 ```jsx
-const { GoogleMap, LoadScript, Marker } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Polygon.md
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.md
@@ -1,7 +1,7 @@
 # Polygon example
 
 ```jsx
-const { GoogleMap, LoadScript, Polygon } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Polyline.md
+++ b/packages/react-google-maps-api/src/components/drawing/Polyline.md
@@ -1,7 +1,7 @@
 # Polyline example
 
 ```jsx
-const { GoogleMap, LoadScript, Polyline } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/drawing/Rectangle.md
+++ b/packages/react-google-maps-api/src/components/drawing/Rectangle.md
@@ -1,7 +1,7 @@
 # Rectangle example
 
 ```jsx
-const { GoogleMap, LoadScript, Rectangle } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.md
+++ b/packages/react-google-maps-api/src/components/heatmap/HeatmapLayer.md
@@ -1,7 +1,7 @@
 # HeatmapLayer example
 
 ```jsx
-const { GoogleMap, LoadScript, HeatmapLayer } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/kml/KmlLayer.md
+++ b/packages/react-google-maps-api/src/components/kml/KmlLayer.md
@@ -1,7 +1,7 @@
 # KML Layer example
 
 ```jsx
-const { GoogleMap, LoadScript, Circle } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/maps/BicyclingLayer.md
+++ b/packages/react-google-maps-api/src/components/maps/BicyclingLayer.md
@@ -1,7 +1,7 @@
 # BicyclingLayer example
 
 ```jsx
-const { GoogleMap, LoadScript, BicyclingLayer } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/maps/TrafficLayer.md
+++ b/packages/react-google-maps-api/src/components/maps/TrafficLayer.md
@@ -1,7 +1,7 @@
 # TrafficLayer example
 
 ```jsx
-const { GoogleMap, LoadScript, TrafficLayer } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/overlays/GroundOverlay.md
+++ b/packages/react-google-maps-api/src/components/overlays/GroundOverlay.md
@@ -1,7 +1,7 @@
 # Ground Overlay example
 
 ```jsx
-const { GoogleMap, LoadScript, GroundOverlay } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.md
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.md
@@ -4,7 +4,7 @@ Look at the console.log to see search results
 
 ```jsx
 const { Component } = require('react')
-const { GoogleMap, LoadScript, Autocomplete } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 class MyMapWithAutocomplete extends Component {

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.md
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.md
@@ -3,7 +3,7 @@
 Look at the console.log to see search results
 
 ```jsx
-const { GoogleMap, LoadScript, StandaloneSearchBox } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.md
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.md
@@ -1,7 +1,7 @@
 # StreetViewPanorama example
 
 ```jsx
-const { GoogleMap, LoadScript, StreetViewPanorama } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewService.md
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewService.md
@@ -4,7 +4,7 @@ Look at the console.log to see request results
 
 
 ```jsx
-const { GoogleMap, LoadScript, StreetViewService } = require("../../");
+const { GoogleMap, LoadScript } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>

--- a/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
+++ b/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
@@ -8,10 +8,10 @@ interface ScriptLoadedProps {
   children: React.ReactChild | React.ReactChildren | Function;
 }
 
-function SpanIntro (): JSX.Element {
+function SpanIntro(): JSX.Element {
   return (
     <span>
-      <a href='#introduction'>Enter API Key</a> to see examples
+      <a href='#section-introduction'>Enter API Key</a> to see examples
     </span>
   )
 }
@@ -39,7 +39,7 @@ class ScriptLoaded extends React.Component<ScriptLoadedProps, ScriptLoadedState>
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   checkIfScriptLoaded = () => {
-    function serScriptLoaded () {
+    function serScriptLoaded() {
       return {
         scriptLoaded: true
       }
@@ -54,7 +54,7 @@ class ScriptLoaded extends React.Component<ScriptLoadedProps, ScriptLoadedState>
     }
   }
 
-  componentWillUnmount () {
+  componentWillUnmount() {
     window.clearInterval(this.interval)
   }
 
@@ -63,7 +63,7 @@ class ScriptLoaded extends React.Component<ScriptLoadedProps, ScriptLoadedState>
       return <SpanIntro />
     }
 
-    return (this.props.children instanceof Function) ?  this.props.children() : this.props.children
+    return (this.props.children instanceof Function) ? this.props.children() : this.props.children
   }
 }
 

--- a/packages/react-google-maps-api/src/docs/getting-started.md
+++ b/packages/react-google-maps-api/src/docs/getting-started.md
@@ -1,5 +1,3 @@
-# Getting Started
-
 ## Install @react-google-maps/api
 
 ```bash

--- a/packages/react-google-maps-api/src/docs/introduction.md
+++ b/packages/react-google-maps-api/src/docs/introduction.md
@@ -1,5 +1,3 @@
-# Introduction
-
  *This library requires React v16.6 or later. If you need support for earlier versions of React, you should check out [react-google-maps](https://github.com/tomchentw/react-google-maps)*
 
 This is complete re-write of the (sadly unmaintained) `react-google-maps` library. We thank [tomchentw](https://github.com/tomchentw/) for his great work that made possible.


### PR DESCRIPTION
 * Added short documentation about `useGoogleMap` existence.
 * Removed double titles for Introduction & Getting started.

Also fixed interactive examples which were being displayed like this...

![image](https://user-images.githubusercontent.com/1096340/59095040-d3ab9000-8917-11e9-8c0e-69011d9ef67d.png)

For some reason, it auto-imports component being shown so it fails. See the [build preview](https://5cfa2fd986ea9a00084f529b--react-google-maps-api-docs.netlify.com/#directionsrenderer) for comparison.