### PR TITLE
Fixes if innerText is missing for that given tag

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -161,7 +161,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
     Array.prototype.slice
       .call(document.getElementsByTagName("style"))
       .filter(function filter(style: HTMLStyleElement): boolean {
-        return style.innerText.length > 0 && style.innerText.includes(".gm-")
+        return style.innerText && style.innerText.length > 0 && style.innerText.includes(".gm-")
       })
       .forEach(function forEach(style: HTMLStyleElement) {
         if (style.parentNode) {


### PR DESCRIPTION
It's possible that for few html style elements innerText attritubute is missing and only innerHTML attribute is available. In that scenario, this code would break without a proper check like style.innerText && 

# Please explain PR reason.
