### PR TITLE
Remove `console.log` debug lines in ts files (under `react-google-map…

### DIFF
--- a/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
+++ b/packages/react-google-maps-api/src/components/kml/KmlLayer.tsx
@@ -20,7 +20,6 @@ const updaterMap = {
     instance.setOptions(options)
   },
   url(instance: google.maps.KmlLayer, url: string) {
-    console.log({instance, url})
     instance.setUrl(url)
   },
   zIndex(instance: google.maps.KmlLayer, zIndex: number) {

--- a/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
+++ b/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
@@ -58,8 +58,6 @@ export class GroundOverlay extends React.PureComponent<
   }
 
   componentDidMount() {
-    console.log('this.props.url: ', this.props.url)
-    console.log('this.props.bounds: ', this.props.bounds)
     invariant(
       !!this.props.url || !!this.props.bounds,
       `For GroundOveray, url and bounds are passed in to constructor and are immutable after instantiated. This is the behavior of Google Maps JavaScript API v3 ( See https://developers.google.com/maps/documentation/javascript/reference#GroundOverlay) Hence, use the corresponding two props provided by \`react-google-maps-api\`, url and bounds. In some cases, you'll need the GroundOverlay component to reflect the changes of url and bounds. You can leverage the React's key property to remount the component. Typically, just \`key={url}\` would serve your need. See https://github.com/tomchentw/react-google-maps/issues/655`

--- a/packages/react-google-maps-api/src/utils/prevent-google-fonts.ts
+++ b/packages/react-google-maps-api/src/utils/prevent-google-fonts.ts
@@ -46,7 +46,6 @@ const isRobotoStyle = (element: HTMLElement) => {
 
 // Preventing the Google Maps libary from downloading an extra font
 export const preventGoogleFonts = () => {
-  console.log('preventGoogleFonts run')
   // we override these methods only for one particular head element
   // default methods for other elements are not affected
   const head = document.getElementsByTagName("head")[0]


### PR DESCRIPTION
This PR removes the `console.log` statements in typescript files and components under the `react-google-map-api/src` folder, those which seemed to be used purely for debugging 🐛 

closes #161 