### PR TITLE
Use js-fetch for useLoadScript

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -83,7 +83,8 @@
   },
   "dependencies": {
     "@react-google-maps/marker-clusterer": "1.2.6",
-    "invariant": "2.2.4"
+    "invariant": "2.2.4",
+    "js-fetch": "^1.3.1"
   },
   "peerDependencies": {
     "react": "^16.6.3",

--- a/packages/react-google-maps-api/src/utils/js-fetch.d.ts
+++ b/packages/react-google-maps-api/src/utils/js-fetch.d.ts
@@ -1,0 +1,1 @@
+declare module 'js-fetch'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,6 +3038,11 @@
   resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.36.3.tgz#3d3dded3b56f8369b3a6ffafc408473037fb34c7"
   integrity sha512-VDB9ub0q5hf/Ri/bblc9Q/rzqE95CzZCSWMcpeVzmzr+w2Kef2fRnnr5QZBePhbqNh8GNyfac812A46eqwcWeg==
 
+"@types/googlemaps@^3.36.4":
+  version "3.36.5"
+  resolved "https://registry.yarnpkg.com/@types/googlemaps/-/googlemaps-3.36.5.tgz#9fa57d430e4982ce9f2352e1a48dfe5c294fe868"
+  integrity sha512-ft36SAiK2eJIC+dovC8iJNbfREYAq7toDizRttCLV7tX427s72LXwSW9aWjbS+pLRbMhjV29WBR8iGvtytRuNg==
+
 "@types/history@*":
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.2.tgz#0e670ea254d559241b6eeb3894f8754991e73220"
@@ -11337,6 +11342,13 @@ jpjs@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/jpjs/-/jpjs-1.2.1.tgz#f343833de8838a5beba1f42d5a219be0114c44b7"
   integrity sha512-GxJWybWU4NV0RNKi6EIqk6IRPOTqd/h+U7sbtyuD7yUISUzV78LdHnq2xkevJsTlz/EImux4sWj+wfMiwKLkiw==
+
+js-fetch@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/js-fetch/-/js-fetch-1.3.1.tgz#a6cb0bd548cc774efcd26523d0745c2cf385dd02"
+  integrity sha1-pssL1UjMd0780mUj0HRcLPOF3QI=
+  dependencies:
+    core-js "^2.5.7"
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
So after some short use of `useLoadScript` it turned out that obnoxious `google is not defined` is still present. It seems that `onLoad` simply fires too soon before the script is actually processed and attached to `window.google`.

I tried switching to `scriptjs` which does some extra magic and it seems that it fixed the problem. I have tried to investigate what are they doing differently, but given up. Unfortunately, then I noticed it does not support handling load errors.

I found [js-fetch](https://github.com/nghiepit/js-fetch) instead which even has google maps api in readme example, so that should make it like a right tool for the job. It actually checks if `window.google` is present before resolving. As a bonus, the `useLoadScript` returns the `google` object so it's possible to access it without awkward `ts-ignore` when accessing `window`.