### PR TITLE
README tweak: Spectrum community, React 16.8 if you want hooks

### DIFF
--- a/packages/react-google-maps-api/README.md
+++ b/packages/react-google-maps-api/README.md
@@ -4,7 +4,7 @@
 
 @react-google-maps/api
 
-> This library requires React v16.6 or later. If you need support for earlier versions of React, you should check out [react-google-maps](https://github.com/tomchentw/react-google-maps)
+> This library requires React v16.6 or later. To use the latest features (including hooks) requires React v16.8+. If you need support for earlier versions of React, you should check out [react-google-maps](https://github.com/tomchentw/react-google-maps)
 
 This is complete re-write of the (sadly unmaintained) `react-google-maps` library. We thank [tomchentw](https://github.com/tomchentw/) for his great work that made possible.
 
@@ -46,6 +46,10 @@ Examples can be found in two places:
 ## Advice
 
 > Using the examples requires you to generate a google maps api key. For instructions on how to do that please see the following [guide](https://developers.google.com/maps/documentation/embed/get-api-key)
+
+## Community Help Resource
+
+You can join the community at https://spectrum.chat/react-google-maps to ask questions and help others with your experience.
 
 ## Contribute
 


### PR DESCRIPTION
Added note and link to Spectrum help community. Noted that React v16.8+ required for latest features including hooks.


