### PR TITLE
Adds ability to pass map instance into the GoogleMaps component

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -79,6 +79,7 @@ export interface GoogleMapProps {
   center?: google.maps.LatLng | google.maps.LatLngLiteral;
   clickableIcons?: boolean;
   heading?: number;
+  map?: google.maps.Map;
   mapTypeId?: string;
   streetView?: google.maps.StreetViewPanorama;
   tilt?: number;
@@ -117,7 +118,7 @@ export class GoogleMap extends React.PureComponent<GoogleMapProps, GoogleMapStat
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   getInstance = (): google.maps.Map | null => {
-    return new google.maps.Map(this.mapRef, this.props.options)
+    return this.props.map || new google.maps.Map(this.mapRef, this.props.options)
   }
 
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
@@ -131,6 +132,11 @@ export class GoogleMap extends React.PureComponent<GoogleMapProps, GoogleMapStat
 
   componentDidMount() {
     const map = this.getInstance()
+
+    if(this.props.map){
+      this.mapRef.appendChild(myFormDomElement)
+      map.setOptions(this.props.options)
+    }
 
     this.registeredEvents = applyUpdatersToPropsAndRegisterEvents({
       updaterMap,

--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -133,8 +133,8 @@ export class GoogleMap extends React.PureComponent<GoogleMapProps, GoogleMapStat
   componentDidMount() {
     const map = this.getInstance()
 
-    if(this.props.map){
-      this.mapRef.appendChild(myFormDomElement)
+    if(this.props.map && map){
+      this.mapRef.appendChild(map.getDiv())
       map.setOptions(this.props.options)
     }
 


### PR DESCRIPTION
# Please explain PR reason.
Google charges for each instance of a map created: https://cloud.google.com/maps-platform/pricing/sheet/  

Allowing a user to pass in an existing instance adds flexibility to the library.