### PR TITLE
Fixed #182 - onOverlayComplete not called 

### DIFF
--- a/packages/react-google-maps-api/src/utils/helper.ts
+++ b/packages/react-google-maps-api/src/utils/helper.ts
@@ -75,6 +75,7 @@ export function applyUpdatersToPropsAndRegisterEvents({
   nextProps: any;
   instance: any;
 }) {
+  const registeredEvents = registerEvents(nextProps, instance, eventMap)
   applyUpdaterToNextProps(updaterMap, prevProps, nextProps, instance)
-  return registerEvents(nextProps, instance, eventMap)
+  return registeredEvents
 }


### PR DESCRIPTION
current  - Events are unregistered, then updates are applied, then evens are re-registered
This causes a bug that if an update needs to cause an event call, that event isn't registered at the time of the update. (as seen in #182)

Switching the order solves this issue