### PR TITLE
Use callback instead of onload to resolve injectScript as loaded!

### DIFF
--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -9,8 +9,6 @@ interface InjectScriptArg {
   id: string;
 }
 
-const windowWithGoogleMap: WindowWithGoogleMap = window
-
 export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
   if (!isBrowser) {
     return Promise.reject(new Error("document is undefined"))
@@ -27,6 +25,11 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
       else {
         existingScript.remove()
       }
+    }
+    const windowWithGoogleMap: WindowWithGoogleMap = window
+
+    if (document.getElementById(id)) {
+      return resolve(id)
     }
 
     const script = document.createElement("script")

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -1,9 +1,15 @@
 import { isBrowser } from "./isbrowser"
 
+interface WindowWithGoogleMap extends Window {
+  initMap?: () => void
+}
+
 interface InjectScriptArg {
   url: string;
   id: string;
 }
+
+const windowWithGoogleMap: WindowWithGoogleMap = window
 
 export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
   if (!isBrowser) {
@@ -29,10 +35,11 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     script.src = url
     script.id = id
     script.async = true
-    script.onload = function onload() {
+    script.onerror = reject
+
+    windowWithGoogleMap.initMap = function onload() {
       resolve(id)
     }
-    script.onerror = reject
 
     document.head.appendChild(script)
   })

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -46,5 +46,7 @@ export function makeLoadScriptUrl({
     params.push(`libraries=${libraries.join(",")}`)
   }
 
+  params.push('callback=initMap')
+
   return `https://maps.googleapis.com/maps/api/js?${params.join('&')}`
 }


### PR DESCRIPTION
# Please explain PR reason.

According #184 

`onload` of `script` DOM will be call after the script is loaded.

However it doesn't mean that `google` is ready to be used in your app.

According Google Map Javascript document, it recommends to be use `callback` function to continue the process after `google` is ready.

In this PR, I created `initMap` function as global function for make it resolve script after `google` is ready in your app.