### PR TITLE
fix useLoadScript not resetting its state when id/url is changed

### DIFF
--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -8,7 +8,7 @@ import { preventGoogleFonts } from './utils/prevent-google-fonts'
 import { makeLoadScriptUrl, LoadScriptUrlOptions } from './utils/make-load-script-url'
 
 import { defaultLoadScriptProps } from './LoadScript'
-import { useCallback } from 'react'
+import useIsMounted from './utils/useIsMounted'
 
 export interface UseLoadScriptOptions extends LoadScriptUrlOptions {
   id?: string;
@@ -16,17 +16,6 @@ export interface UseLoadScriptOptions extends LoadScriptUrlOptions {
 }
 
 let previouslyLoadedUrl: string
-
-const useIsMounted = () => {
-  const isMountedRef = React.useRef(false)
-  React.useEffect(function trackMountedState() {
-    isMountedRef.current = true
-    return () => {
-      isMountedRef.current = false
-    }
-  }, [])
-  return () => isMountedRef.current
-}
 
 export function useLoadScript({
   id = defaultLoadScriptProps.id,

--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -25,7 +25,7 @@ const useIsMounted = () => {
       isMountedRef.current = false
     }
   }, [])
-  return useCallback(() => isMountedRef.current,[]);
+  return () => isMountedRef.current
 }
 
 export function useLoadScript({

--- a/packages/react-google-maps-api/src/utils/useAtMostOnce.ts
+++ b/packages/react-google-maps-api/src/utils/useAtMostOnce.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 import { useEffect } from 'react'
 
 export const createUseAtMostOnce = (
-  errorMessage?: string = 'This hook can only be mounted once per application'
+  errorMessage: string = 'This hook can only be mounted once per application'
 ) => {
   const ref: React.MutableRefObject<boolean> = { current: false }
 

--- a/packages/react-google-maps-api/src/utils/useAtMostOnce.ts
+++ b/packages/react-google-maps-api/src/utils/useAtMostOnce.ts
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { useEffect } from 'react'
+
+export const createUseAtMostOnce = (
+  errorMessage?: string = 'This hook can only be mounted once per application'
+) => {
+  const ref: React.MutableRefObject<boolean> = { current: false }
+
+  const useAtMostOnce = () => {
+    useEffect(() => {
+      if (ref.current) {
+        throw new Error(errorMessage)
+      } else {
+        ref.current = true
+      }
+      return () => {
+        ref.current = false
+      }
+    }, [])
+  }
+
+  return useAtMostOnce
+}

--- a/packages/react-google-maps-api/src/utils/useIsMounted.ts
+++ b/packages/react-google-maps-api/src/utils/useIsMounted.ts
@@ -8,7 +8,7 @@ const useIsMounted = () => {
       isMountedRef.current = false
     }
   }, [])
-  return () => isMountedRef.current
+  return isMountedRef
 }
 
 export default useIsMounted;

--- a/packages/react-google-maps-api/src/utils/useIsMounted.tsx
+++ b/packages/react-google-maps-api/src/utils/useIsMounted.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+const useIsMounted = () => {
+  const isMountedRef = React.useRef(false)
+  React.useEffect(function trackMountedState() {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+  return () => isMountedRef.current
+}
+
+export default useIsMounted;

--- a/packages/react-google-maps-api/src/utils/usePrevious.ts
+++ b/packages/react-google-maps-api/src/utils/usePrevious.ts
@@ -1,0 +1,11 @@
+import * as React from 'react'
+
+const usePrevious = <T>(value: T): T | undefined => {
+  const ref = React.useRef<T>();
+  React.useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
+
+export default usePrevious;


### PR DESCRIPTION
# Please explain PR reason.

I think if a new script gets inserted, the "loaded: boolean" state should go back to false so that we can wait in consumer code for new script to load

cc @JustFly1984 @FredyC 

Related:
- https://github.com/JustFly1984/react-google-maps-api/issues/186
- https://github.com/JustFly1984/react-google-maps-api/pull/188
- https://github.com/JustFly1984/react-google-maps-api/pull/189