### PR TITLE
injectScript should recreate the script if the url changes

### DIFF
--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -11,8 +11,16 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
   }
 
   return new Promise(function injectScriptCallback(resolve, reject) {
-    if (document.getElementById(id)) {
-      return resolve(id)
+    const existingScript = document.getElementById(id) as HTMLScriptElement | undefined
+    if (existingScript) {
+      // Same script id/url: keep same script
+      if (existingScript.src === url) {
+        return resolve(id)
+      }
+      // Same script id but url changed: recreate the script
+      else {
+        existingScript.remove()
+      }
     }
 
     const script = document.createElement("script")


### PR DESCRIPTION
# Please explain PR reason.

Currently if the id remains constant and the url change, the older script will remain loaded and the new one will not replace the old one. If I just change the lib language, I expect the script to reload with the new language, without having to deal with creating a different id to force a reload.

cc @JustFly1984 @FredyC

Related:
- https://github.com/JustFly1984/react-google-maps-api/issues/186
- https://github.com/JustFly1984/react-google-maps-api/pull/188
- https://github.com/JustFly1984/react-google-maps-api/pull/189