### PR TITLE
in injectScript don't immediately resolve if matching script is in the dom

### DIFF
--- a/packages/react-google-maps-api/src/__tests__/utils/injectscript.test.ts
+++ b/packages/react-google-maps-api/src/__tests__/utils/injectscript.test.ts
@@ -4,21 +4,7 @@ interface WindowWithGoogleMap extends Window {
   initMap?: () => void;
 }
 
-// interface ScriptWithOnErrorHandler extends Element {
-//     onerror?: (err: Error) => void;
-// }
-
 describe('utils/injectScript', () => {
-  // let urls: string[] = [];
-
-  // function createScriptUrl(script = '(function(){ var a = 1; })()') {
-  //     const b = new Blob([script], { type: 'text/javascript' });
-  //     const url = URL.createObjectURL(b);
-  //     urls.push(url)
-  //     return url;
-  // }
-
-  // afterAll(() => urls.forEach(url => URL.revokeObjectURL(url)));
 
   describe('injectScript', () => {
     it('adds a script to the page with id and src attributes that correspond to the id and url properties', () => {
@@ -59,28 +45,6 @@ describe('utils/injectScript', () => {
       })
         .then(value => expect(value).toBeTruthy())
     })
-
-
-    // it('returns a promise which rejects if the script does not load', () => {
-    //     const id = 'injectScript-test3'
-    //     const url = `http://localhost/script3.js`
-
-    //     setTimeout(() => {
-    //         const script: ScriptWithOnErrorHandler | null = document.querySelector(id);
-    //         console.log(script && script.onerror);
-    //         console.log('onerror');
-    //         if(script && script.onerror) {
-    //             script.onerror(new Error());
-    //         }
-    //     }, 0)
-
-    //     return injectScript({
-    //         id,
-    //         url,
-    //     })
-    //         .then(() => expect('This then should not run').toBe(''))
-    //         .catch(value => expect(value).toBeInstanceOf(Error))
-    // })
 
     describe('duplicate calls with matching id and url properties', () => {
       it('do not add another script element to the page', () => {

--- a/packages/react-google-maps-api/src/__tests__/utils/injectscript.test.ts
+++ b/packages/react-google-maps-api/src/__tests__/utils/injectscript.test.ts
@@ -1,0 +1,143 @@
+import { injectScript } from '../../utils/injectscript'
+
+interface WindowWithGoogleMap extends Window {
+  initMap?: () => void;
+}
+
+// interface ScriptWithOnErrorHandler extends Element {
+//     onerror?: (err: Error) => void;
+// }
+
+describe('utils/injectScript', () => {
+  // let urls: string[] = [];
+
+  // function createScriptUrl(script = '(function(){ var a = 1; })()') {
+  //     const b = new Blob([script], { type: 'text/javascript' });
+  //     const url = URL.createObjectURL(b);
+  //     urls.push(url)
+  //     return url;
+  // }
+
+  // afterAll(() => urls.forEach(url => URL.revokeObjectURL(url)));
+
+  describe('injectScript', () => {
+    it('adds a script to the page with id and src attributes that correspond to the id and url properties', () => {
+      const url = `http://localhost/script1.js`
+      const value = injectScript({
+        id: 'injectScript-test1',
+        url,
+      })
+
+
+      setTimeout(() => {
+        const win: WindowWithGoogleMap = window
+        if(win.initMap) {
+          win.initMap()
+        }
+      }, 0)
+
+      const element = document.querySelector('#injectScript-test1')
+      expect(element).toBeTruthy()
+      expect(element).toHaveProperty('src', url)
+      return value
+    })
+
+    it('returns a promise which resolves when the script loads', () => {
+      const id = 'injectScript-test2'
+      const url = `http://localhost/script2.js`
+
+      setTimeout(() => {
+        const win: WindowWithGoogleMap = window
+        if(win.initMap) {
+          win.initMap()
+        }
+      }, 0)
+
+      return injectScript({
+        id,
+        url,
+      })
+        .then(value => expect(value).toBeTruthy())
+    })
+
+
+    // it('returns a promise which rejects if the script does not load', () => {
+    //     const id = 'injectScript-test3'
+    //     const url = `http://localhost/script3.js`
+
+    //     setTimeout(() => {
+    //         const script: ScriptWithOnErrorHandler | null = document.querySelector(id);
+    //         console.log(script && script.onerror);
+    //         console.log('onerror');
+    //         if(script && script.onerror) {
+    //             script.onerror(new Error());
+    //         }
+    //     }, 0)
+
+    //     return injectScript({
+    //         id,
+    //         url,
+    //     })
+    //         .then(() => expect('This then should not run').toBe(''))
+    //         .catch(value => expect(value).toBeInstanceOf(Error))
+    // })
+
+    describe('duplicate calls with matching id and url properties', () => {
+      it('do not add another script element to the page', () => {
+        const id = 'injectScript-test4'
+        const url = 'http://localhost/script4.js'
+
+        injectScript({
+          id,
+          url,
+        })
+
+        const value = injectScript({
+          id,
+          url,
+        })
+
+
+        setTimeout(() => {
+          const win: WindowWithGoogleMap = window
+          if(win.initMap) {
+            win.initMap()
+          }
+        }, 0)
+
+        expect(document.querySelectorAll(`script[src="${url}"]`)).toHaveProperty('length', 1)
+        return value
+      })
+
+      it('do not resolve in successive calls unless the script has actually loaded from the first call', () => {
+        const id = 'injectScript-test5'
+        const url = 'http://localhost/script5.js'
+        let initMapCalled = false
+
+        const value1 = injectScript({
+          id,
+          url,
+        })
+
+        const value2 = injectScript({
+          id,
+          url
+        })
+
+        setTimeout(() => {
+          const win: WindowWithGoogleMap = window
+          if(win.initMap) {
+            initMapCalled = true
+            win.initMap()
+          }
+        }, 50)
+
+        return value2.then(() => {
+          expect(initMapCalled).toBe(true)
+          return value1
+        })
+      })
+
+    })
+  })
+})

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -25,7 +25,7 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
         }
         else {
           const onGoogleMapsReadyClosure = windowWithGoogleMap.initMap
-          existingScript.onload = function() {
+          windowWithGoogleMap.initMap = function() {
             if(onGoogleMapsReadyClosure) {
               onGoogleMapsReadyClosure()
             }
@@ -51,6 +51,7 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     script.setAttribute('state', 'loading')
 
     windowWithGoogleMap.initMap = function onload() {
+
       script.setAttribute('state', 'ready')
       resolve(id)
     }

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -48,7 +48,6 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     script.id = id
     script.async = true
     script.onerror = reject
-    script.setAttribute('data-state', 'loading')
 
     windowWithGoogleMap.initMap = function onload() {
 

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -26,7 +26,9 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
         else {
           const onGoogleMapsReadyClosure = windowWithGoogleMap.initMap
           existingScript.onload = function() {
-            onGoogleMapsReadyClosure()
+            if(onGoogleMapsReadyClosure) {
+              onGoogleMapsReadyClosure()
+            }
             resolve(id)
           }
         }

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -24,10 +24,10 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
           return resolve(id)
         }
         else {
-          const onGoogleMapsReadyClosure = windowWithGoogleMap.initMap
+          const originalInitMap = windowWithGoogleMap.initMap
           windowWithGoogleMap.initMap = function() {
-            if(onGoogleMapsReadyClosure) {
-              onGoogleMapsReadyClosure()
+            if(originalInitMap) {
+              originalInitMap()
             }
             resolve(id)
           }

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -20,7 +20,7 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     if (existingScript) {
       // Same script id/url: keep same script
       if (existingScript.src === url) {
-        if(existingScript.getAttribute('state') === 'ready') {
+        if(existingScript.getAttribute('data-state') === 'ready') {
           return resolve(id)
         }
         else {
@@ -48,11 +48,11 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     script.id = id
     script.async = true
     script.onerror = reject
-    script.setAttribute('state', 'loading')
+    script.setAttribute('data-state', 'loading')
 
     windowWithGoogleMap.initMap = function onload() {
 
-      script.setAttribute('state', 'ready')
+      script.setAttribute('data-state', 'ready')
       resolve(id)
     }
 

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -31,16 +31,14 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
             }
             resolve(id)
           }
+
+          return
         }
       }
       // Same script id but url changed: recreate the script
       else {
         existingScript.remove()
       }
-    }
-
-    if (document.getElementById(id)) {
-      return resolve(id)
     }
 
     const script = document.createElement("script")

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -43,7 +43,7 @@ export function makeLoadScriptUrl({
   }
 
   if (libraries && libraries.length) {
-    params.push(`libraries=${libraries.join(",")}`)
+    params.push(`libraries=${libraries.sort().join(",")}`)
   }
 
   params.push('callback=initMap')


### PR DESCRIPTION
When injectScript runs it checks for the presence of a script element with matching ID in the DOM. If it finds it, it immediately resolves, regardless of whether the script has finished loading or not.

This changes add a 'state' attribute to the script that can be used to check if the google maps is ready or not and then use that information to decide whether to resolve immediately.

There are a couple of possible issues. I would probably prefer using `script.addEventListener('load', callback)` instead of `script.onload` and then using the closure to maintain a reference back to the original call to injectScript's onload callback. That's just what I prefer but attempting with changing the source as little as possible to implement the feature.

I have seen in other threads the mention of removing the id from the call but that it was needed to to find the script via document.getElementById. Why not use the below to find scripts according to just the url? I am not sure if this has been considered but found to be not suitable or not?

```
document.querySelector(`script[src="${ url }"]`)
```