### PR TITLE
Build UMD too

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/package.json
+++ b/packages/react-google-maps-api-marker-clusterer/package.json
@@ -36,7 +36,7 @@
     "Marker"
   ],
   "scripts": {
-    "build": "npx tsdx build --name markerClusterer",
+    "build": "npx tsdx build --name markerClusterer --format=cjs,esm,umd",
     "clean": "rimraf ./package-lock.json ./yarn.lock ./node_modules/ && yarn",
     "update": "yarn-check -u",
     "lint": "npx eslint ./src/**/*.{ts,tsx}",

--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -69,7 +69,7 @@
     "Typescript"
   ],
   "scripts": {
-    "build": "npx tsdx build --name reactGoogleMapsApi",
+    "build": "npx tsdx build --name reactGoogleMapsApi --format=cjs,esm,umd",
     "clean": "rimraf ./package-lock.json ./yarn.lock ./node_modules/ && yarn",
     "update": "yarn-check -u",
     "lint": "npx eslint ./src/**/*.{ts,tsx}",


### PR DESCRIPTION
@JustFly1984 Latest TSDX doesn't build UMD by default, so it needs to be specified. This is the fix for https://github.com/JustFly1984/react-google-maps-api/pull/194#issuecomment-516860162