### PR TITLE
Fix paths for built files

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/package.json
+++ b/packages/react-google-maps-api-marker-clusterer/package.json
@@ -21,8 +21,8 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "unpkg": "dist/markerclusterer.umd.production.js",
-  "module": "dist/markerclusterer.es.production.js",
+  "unpkg": "dist/markerclusterer.umd.production.min.js",
+  "module": "dist/markerclusterer.esm.js",
   "files": [
     "src/",
     "dist/"
@@ -36,6 +36,7 @@
     "Marker"
   ],
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "npx tsdx build --name markerClusterer --format=cjs,esm,umd",
     "clean": "rimraf ./package-lock.json ./yarn.lock ./node_modules/ && yarn",
     "update": "yarn-check -u",

--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -27,8 +27,8 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "unpkg": "dist/reactgooglemapsapi.umd.production.js",
-  "module": "dist/reactgooglemapsapi.es.production.js",
+  "unpkg": "dist/reactgooglemapsapi.umd.production.min.js",
+  "module": "dist/reactgooglemapsapi.esm.js",
   "files": [
     "src/",
     "dist/"
@@ -69,6 +69,7 @@
     "Typescript"
   ],
   "scripts": {
+    "prebuild": "rimraf dist",
     "build": "npx tsdx build --name reactGoogleMapsApi --format=cjs,esm,umd",
     "clean": "rimraf ./package-lock.json ./yarn.lock ./node_modules/ && yarn",
     "update": "yarn-check -u",


### PR DESCRIPTION
Discovered another build related issue, we were referring to old files. TSDX has changed the way how are output files named slightly. I've also added cleanup of dist before build to avoid having old code in there.

To explain the ESM format, there is no longer dev/prod variant as that's up to the consumer. It was actually an issue in this project that has lead me to [discover the problem](https://github.com/palmerhq/tsdx/issues/140).

cc @JustFly1984 @uriklar 