### PR TITLE
Allow for adding a channel to the maps url

### DIFF
--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -25,6 +25,7 @@ export function useLoadScript({
   region,
   libraries,
   preventGoogleFontsLoading,
+  channel,
 }: UseLoadScriptOptions) {
   const isMounted = React.useRef(false)
   const [isLoaded, setLoaded] = React.useState(false)
@@ -53,7 +54,7 @@ export function useLoadScript({
     }
   }, [isLoaded])
 
-  const url = makeLoadScriptUrl({ version, googleMapsApiKey, googleMapsClientId, language, region, libraries })
+  const url = makeLoadScriptUrl({ version, googleMapsApiKey, googleMapsClientId, language, region, libraries, channel })
 
   React.useEffect(function loadScriptAndModifyLoadedState() {
     if (!isBrowser) {

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -7,6 +7,7 @@ export interface LoadScriptUrlOptions {
   language?: string;
   region?: string;
   libraries?: string[];
+  channel?: string;
 }
 
 export function makeLoadScriptUrl({
@@ -15,7 +16,8 @@ export function makeLoadScriptUrl({
   version = 'weekly',
   language,
   region,
-  libraries
+  libraries,
+  channel
 }: LoadScriptUrlOptions) {
   const params = []
 
@@ -44,6 +46,10 @@ export function makeLoadScriptUrl({
 
   if (libraries && libraries.length) {
     params.push(`libraries=${libraries.sort().join(",")}`)
+  }
+
+  if (channel) {
+    params.push(`channel=${channel}`)
   }
 
   params.push('callback=initMap')


### PR DESCRIPTION
At the moment it is not possible to add a channel parameter to the maps url by passing it as a prop to `LoadScript`/`useLoadScript`. Channels allow for tracking of usage across different applications using the same client ID. See [Google Maps docs](https://developers.google.com/maps/premium/reports/usage-reports#channels).
