### PR TITLE
Fix broken InfoBox import in docs

### DIFF
--- a/packages/react-google-maps-api/src/components/addons/InfoBox.md
+++ b/packages/react-google-maps-api/src/components/addons/InfoBox.md
@@ -1,7 +1,7 @@
 # InfoBox example
 
 ```jsx
-const { GoogleMap, LoadScript } = require("../../");
+const { GoogleMap, LoadScript, InfoBox } = require("../../");
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
 
 <ScriptLoaded>


### PR DESCRIPTION
# Please explain PR reason.
The example for the `InfoBox` component in docs was broken due to a missing import.

![Screen Shot 2019-09-10 at 10 56 01 AM](https://user-images.githubusercontent.com/12487270/64627243-43b92e80-d3bd-11e9-91ad-3159966bd31f.png)
