### PR TITLE
Fix using 'TOP_LEFT' as controlPosition in Data docs

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Data.md
+++ b/packages/react-google-maps-api/src/components/drawing/Data.md
@@ -22,7 +22,7 @@ const ScriptLoaded = require("../../docs/ScriptLoaded").default;
         console.log('data: ', data)
       }}
       options={{
-        controlPosition: "TOP_LEFT",
+        controlPosition: window.google ? window.google.maps.ControlPosition.TOP_LEFT : undefined,
         controls: ["Point"],
         drawingMode: "Point", //  "LineString" or "Polygon".
         featureFactory: geometry => {


### PR DESCRIPTION
# Please explain PR reason.

Using the string `'TOP_LEFT'` as the value for `controlPosition` of `Data` produces this error: `InvalidValueError: setControlPosition: TOP_LEFT`.

Changed that to just use the actual value from google maps, but had to wrap it in a condition because `window.google` started out as `undefined`.