### PR TITLE
panTo() function. Centering map smoothly.

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -149,6 +149,13 @@ export class GoogleMap extends React.PureComponent<GoogleMapProps, GoogleMapStat
     return new google.maps.Map(this.mapRef, this.props.options)
   }
 
+  panTo = (latLng: google.maps.LatLng | google.maps.LatLngLiteral): void => {
+    const map = this.getInstance(); 
+    if(map) {
+      map.panTo(latLng);
+    }
+  }
+
   // eslint-disable-next-line @getify/proper-arrows/this, @getify/proper-arrows/name
   setMapCallback = () => {
     if (this.state.map !== null) {


### PR DESCRIPTION
The panTo() function has the purpose of centering a position smoothly. 

I am not sure if it is best to use "this.getInstance()" or "this.state.map" as input parameter to the "map.panTo()" function. I have used "this.getInstance()" for now. 

# Please explain PR reason.
At the moment there is no function that centers a pin/position on the map smoothly.
It is possible to center a pin, but not with a smooth animation - which is included in the panTo() function.  
