### PR TITLE
fix(Marker): correct options type

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -89,7 +89,7 @@ interface MarkerState {
 }
 
 export interface MarkerProps {
-  options?: google.maps.MapOptions;
+  options?: google.maps.MarkerOptions;
   /** Start an animation. Any ongoing animation will be cancelled. Currently supported animations are: BOUNCE, DROP. Passing in null will cause any animation to stop. */
   animation?: google.maps.Animation;
   /** If true, the marker receives mouse and touch events. Default value is true. */


### PR DESCRIPTION
It should be `google.maps.MarkerOptions` not `google.maps.MapOptions`
