### PR TITLE
fix infobox extend function

### DIFF
--- a/packages/react-google-maps-api-infobox/src/InfoBox.tsx
+++ b/packages/react-google-maps-api-infobox/src/InfoBox.tsx
@@ -677,7 +677,11 @@ export class InfoBox {
       for (const property in object.prototype) {
         // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
         // @ts-ignore
-        this.prototype[property] = object.prototype[property]
+        if (!this.prototype.hasOwnProperty(property)) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+          // @ts-ignore
+          this.prototype[property] = object.prototype[property]
+        }
       }
 
       // eslint-disable-next-line @typescript-eslint/ban-ts-ignore


### PR DESCRIPTION
# Please explain PR reason.
As mentioned in https://spectrum.chat/react-google-maps/general/infobox-doesnt-react-to-options-change~fc8e01bd-3d2a-485c-880d-4a5002a13481, infobox didn't react to options changes. This quickfix solves the issue.