### PR TITLE
Ensure that all onerror callbacks are called on a script load error

### DIFF
--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -34,7 +34,9 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
           }
 
           existingScript.onerror = function(err) {
-            originalErrorCallback(err)
+            if (originalErrorCallback) {
+              originalErrorCallback(err)
+            }
             reject(err)
           }
 

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -24,11 +24,18 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
           return resolve(id)
         } else {
           const originalInitMap = windowWithGoogleMap.initMap
+          const originalErrorCallback = existingScript.onerror
+
           windowWithGoogleMap.initMap = function initMap() {
             if (originalInitMap) {
               originalInitMap()
             }
             resolve(id)
+          }
+
+          existingScript.onerror = function(err) {
+            originalErrorCallback(err)
+            reject(err)
           }
 
           return


### PR DESCRIPTION
Currently, only the first `onerror` callback is called when a script fails to load. This pull request just uses a closure to be able to recursively call all `onerror` callbacks in the same way that the `initMap` callbacks are recursively called