### PR TITLE
after logging the error from inject script rethrow it

### DIFF
--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -65,5 +65,6 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     document.head.appendChild(script)
   }).catch(err => {
     console.error('injectScript error: ', err)
+    throw err
   })
 }


### PR DESCRIPTION
I realised that I forgot to put this important line into my previous commit. Sorry for making this be split over two releases now 🙈 

After logging the error from inject script ensure that we rethrow the original error so that any promises chain outside of the `injectScript` function is still able to catch the error and handle it according to their own logic. Specifically used in useLoadScript hook. Which, without this fix always assumes that the script loads and then error when trying to access `window.google.maps`

