### PR TITLE
Added Shipwrecks.cc as an example of a site that uses @react-google-maps/api

### DIFF
--- a/packages/react-google-maps-api/README.md
+++ b/packages/react-google-maps-api/README.md
@@ -108,4 +108,6 @@ Since version 1.2.2 We added useGoogleMap hook, which is working only with React
 
 [DriveFromTo.com](https://www.drivefromto.com/en) Transfer Booking service PWA.
 
+[Shipwrecks.cc](https://shipwrecks.cc/) Shipwrecks from Wikipedia visualized on the map [(Github)](https://github.com/lauriharpf/shipwrecks)
+
 add your website by making PR!


### PR DESCRIPTION
Converted an old hobby project from AngularJS to React during the holiday season. Wanted a good Google Maps library to do so: After a bit of digging, `@react-google-maps/api` felt like the best alternative.

If you want examples of websites that use this library, here's one more. Thanks for making using Google Maps with React so convenient.