### PR TITLE
Delete `engines` from `package.json`

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -9,9 +9,6 @@
     "email": "justfly1984@gmail.com",
     "url": "https://github.com/JustFly1984"
   },
-  "engines": {
-    "node": ">=12.13.1"
-  },
   "contributors": [
     "Uri Klar <uriklar@gmail.com> (https://github.com/uriklar)",
     "Ignat Awwit <ignatius.awwit@gmail.com> (https://github.com/awwit)",


### PR DESCRIPTION
PR is to address this issue https://github.com/JustFly1984/react-google-maps-api/issues/430