### PR TITLE
fix #867 - handle script tags with `null` src on cleanup

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -133,7 +133,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
     Array.prototype.slice
       .call(document.getElementsByTagName('script'))
       .filter(function filter(script: HTMLScriptElement): boolean {
-        return script.src.includes('maps.googleapis')
+        return !!script.src && script.src.includes('maps.googleapis')
       })
       .forEach(function forEach(script: HTMLScriptElement): void {
         if (script.parentNode) {


### PR DESCRIPTION
fix #867
