### PR TITLE
docs(api): add needed props to get a functional rendered map

### DIFF
--- a/packages/react-google-maps-api/src/docs/getting-started.md
+++ b/packages/react-google-maps-api/src/docs/getting-started.md
@@ -13,6 +13,8 @@ The two basic components required to use this library are:
 * LoadScript - Loads the Google Maps API script
 * GoogleMap - The map component inside which all other components render
 
+The simplest way to get a functional map is:
+
 ```js static
 import React, { Component } from 'react'
 import { GoogleMap, LoadScript } from '@react-google-maps/api'
@@ -21,15 +23,14 @@ class MyComponents extends Component {
   render() {
      return (
       <LoadScript
-        id="script-loader"
         googleMapsApiKey="YOUR_API_KEY"
-        {...other props}
       >
         <GoogleMap
-          id='example-map'
-          {...other props }
+          mapContainerStyle={{ width: '400px', height: '400px' }}
+          zoom={10}
+          center={{ lat: -3.745, lng: -38.523 }}
         >
-          ...Your map components
+          { /* Child components, such as markers, info windows, etc. */ }
         </GoogleMap>
       </LoadScript>
      )

--- a/packages/react-google-maps-api/src/docs/getting-started.md
+++ b/packages/react-google-maps-api/src/docs/getting-started.md
@@ -8,32 +8,69 @@ yarn add @react-google-maps/api
 
 ## LoadScript and GoogleMap
 
-The two basic components required to use this library are:
+The two basic components required to load a simple map are:
 
 * LoadScript - Loads the Google Maps API script
 * GoogleMap - The map component inside which all other components render
 
 The simplest way to get a functional map is:
 
-```js static
+> ⚠️ Make sure you cache the props passed to `GoogleMap` to avoid re-renders that may harm the performance.
+
+```js
 import React, { Component } from 'react'
 import { GoogleMap, LoadScript } from '@react-google-maps/api'
 
 class MyComponents extends Component {
+  containerStyle = {
+    width: '400px',
+    height: '400px'
+  };
+
+  center = {
+    lat: -3.745,
+    lng: -38.523
+  };
+
   render() {
-     return (
+    return (
       <LoadScript
         googleMapsApiKey="YOUR_API_KEY"
       >
         <GoogleMap
-          mapContainerStyle={{ width: '400px', height: '400px' }}
+          mapContainerStyle={this.containerStyle}
+          center={this.center}
           zoom={10}
-          center={{ lat: -3.745, lng: -38.523 }}
         >
           { /* Child components, such as markers, info windows, etc. */ }
         </GoogleMap>
       </LoadScript>
-     )
+    )
   }
 }
+```
+
+Or you can also adopt a functional component style:
+
+```js
+import React from 'react'
+
+function MyComponent(props) {
+  const { containerStyle, center } = props;
+  return (
+    <LoadScript
+      googleMapsApiKey="YOUR_API_KEY"
+    >
+      <GoogleMap
+        mapContainerStyle={containerStyle}
+        center={center}
+        zoom={10}
+      >
+        { /* Child components, such as markers, info windows, etc. */ }
+      </GoogleMap>
+    </LoadScript>
+  )
+}
+
+export default React.memo(MyComponent)
 ```


### PR DESCRIPTION
Great job, buddies! :star2: It's been hard to find a maintained library for integrating Google Maps into a React application.

I took the opportunity to add a few changes in the _Getting Started_ section.

Without these properties, we can't see either anything on the screen nor any error message. It might confuse both beginners and even experienced developers.

This PR helps to add the basic props in order to get a functional rendered map on the screen. The users can start working from this point.

In order to have the simplest form, I also removed the `id` props as they seem to be not really required (at least not to get a functional map).