### PR TITLE
Fix load/unmount documentation switch

### DIFF
--- a/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
+++ b/packages/react-google-maps-api/src/components/maps/TrafficLayer.tsx
@@ -17,9 +17,9 @@ interface TrafficLayerState {
 
 export interface TrafficLayerProps {
   options?: google.maps.TrafficLayerOptions
-  /** This callback is called when the component unmounts. It is called with the trafficLayer instance. */
-  onLoad?: (trafficLayer: google.maps.TrafficLayer) => void
   /** This callback is called when the trafficLayer instance has loaded. It is called with the trafficLayer instance. */
+  onLoad?: (trafficLayer: google.maps.TrafficLayer) => void
+  /** This callback is called when the component unmounts. It is called with the trafficLayer instance. */
   onUnmount?: (trafficLayer: google.maps.TrafficLayer) => void
 }
 

--- a/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
+++ b/packages/react-google-maps-api/src/components/overlays/GroundOverlay.tsx
@@ -34,9 +34,9 @@ export interface GroundOverlayProps {
   url: string
   /** The bounds that the image will be scaled to fit */
   bounds: google.maps.LatLngBounds
-  /** This callback is called when the component unmounts. It is called with the groundOverlay instance. */
-  onLoad?: (groundOverlay: google.maps.GroundOverlay) => void
   /** This callback is called when the groundOverlay instance has loaded. It is called with the groundOverlay instance. */
+  onLoad?: (groundOverlay: google.maps.GroundOverlay) => void
+  /** This callback is called when the component unmounts. It is called with the groundOverlay instance. */
   onUnmount?: (groundOverlay: google.maps.GroundOverlay) => void
 }
 

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
@@ -29,9 +29,9 @@ export interface StandaloneSearchBoxProps {
   options?: google.maps.places.SearchBoxOptions
   /** This event is fired when the user selects a query, getPlaces should be used to get new places. */
   onPlacesChanged?: () => void
-  /** This callback is called when the component unmounts. It is called with the searchBox instance. */
-  onLoad?: (searchBox: google.maps.places.SearchBox) => void
   /** This callback is called when the searchBox instance has loaded. It is called with the searchBox instance. */
+  onLoad?: (searchBox: google.maps.places.SearchBox) => void
+  /** This callback is called when the component unmounts. It is called with the searchBox instance. */
   onUnmount?: (searchBox: google.maps.places.SearchBox) => void
 }
 

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewPanorama.tsx
@@ -77,9 +77,9 @@ export interface StreetViewPanoramaProps {
   onVisibleChanged?: () => void
   /** This event is fired when the panorama's zoom level changes. */
   onZoomChange?: () => void
-  /** This callback is called when the component unmounts. It is called with the streetViewPanorama instance. */
-  onLoad?: (streetViewPanorama: google.maps.StreetViewPanorama) => void
   /** This callback is called when the streetViewPanorama instance has loaded. It is called with the streetViewPanorama instance. */
+  onLoad?: (streetViewPanorama: google.maps.StreetViewPanorama) => void
+  /** This callback is called when the component unmounts. It is called with the streetViewPanorama instance. */
   onUnmount?: (streetViewPanorama: google.maps.StreetViewPanorama) => void
 }
 

--- a/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
+++ b/packages/react-google-maps-api/src/components/streetview/StreetViewService.tsx
@@ -3,9 +3,9 @@ import * as React from 'react'
 import MapContext from '../../map-context'
 
 export interface StreetViewServiceProps {
-  /** This callback is called when the component unmounts. It is called with the streetViewService instance. */
-  onLoad?: (streetViewService: google.maps.StreetViewService | null) => void
   /** This callback is called when the streetViewService instance has loaded. It is called with the streetViewService instance. */
+  onLoad?: (streetViewService: google.maps.StreetViewService | null) => void
+  /** This callback is called when the component unmounts. It is called with the streetViewService instance. */
   onUnmount?: (streetViewService: google.maps.StreetViewService | null) => void
 }
 


### PR DESCRIPTION
# Please explain PR reason.
Just noticed that the load and unmount documentation was switched around in some places.