### PR TITLE
Anchoring InfoWindow children of Markers

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -249,11 +249,20 @@ export class Marker extends React.PureComponent<MarkerProps, MarkerState> {
   }
 
   render(): React.ReactNode {
-    let children: ReactNode[]|null = null
+    interface HasMarkerAnchor {
+      anchor?: google.maps.Marker | null
+    }
+
+    let children: ReactNode | null = null
     if(this.props.children) {
-      children = React.Children.toArray(this.props.children).map(
-        (e) => {return React.cloneElement(e, {anchor: this.state.marker})}
-      )
+      children = React.Children.map(this.props.children, child => {
+        if(!React.isValidElement<HasMarkerAnchor>(child)) {
+          return child;
+        }
+
+        let elementChild: React.ReactElement<HasMarkerAnchor> = child;
+        return React.cloneElement(elementChild, {anchor: this.state.marker});
+      })
     }
     return children || null
   }

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -5,6 +5,7 @@ import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../u
 import MapContext from '../../map-context'
 
 import { Clusterer } from '@react-google-maps/marker-clusterer'
+import { ReactNode } from 'react'
 
 const eventMap = {
   onAnimationChanged: 'animation_changed',
@@ -248,11 +249,13 @@ export class Marker extends React.PureComponent<MarkerProps, MarkerState> {
   }
 
   render(): React.ReactNode {
-    let children: JSX.Element|null = null
+    let children: ReactNode[]|null = null
     if(this.props.children) {
-      children = this.props.children.map((e) => {return React.cloneElement(e, {anchor: this.state.marker})})
+      children = React.Children.toArray(this.props.children).map(
+        (e) => {return React.cloneElement(e, {anchor: this.state.marker})}
+      )
     }
-    return this.props.children || null
+    return children || null
   }
 }
 

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -248,6 +248,10 @@ export class Marker extends React.PureComponent<MarkerProps, MarkerState> {
   }
 
   render(): React.ReactNode {
+    let children: JSX.Element|null = null
+    if(this.props.children) {
+      children = this.props.children.map((e) => {return React.cloneElement(e, {anchor: this.state.marker})})
+    }
     return this.props.children || null
   }
 }

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../utils/helper'
 
 import MapContext from '../../map-context'
+import { HasMarkerAnchor } from '../../types'
 
 import { Clusterer } from '@react-google-maps/marker-clusterer'
 import { ReactNode } from 'react'
@@ -249,10 +250,6 @@ export class Marker extends React.PureComponent<MarkerProps, MarkerState> {
   }
 
   render(): React.ReactNode {
-    interface HasMarkerAnchor {
-      anchor?: google.maps.Marker | null
-    }
-
     let children: ReactNode | null = null
     if(this.props.children) {
       children = React.Children.map(this.props.children, child => {

--- a/packages/react-google-maps-api/src/types.tsx
+++ b/packages/react-google-maps-api/src/types.tsx
@@ -1,0 +1,3 @@
+export interface HasMarkerAnchor {
+  anchor?: google.maps.Marker | null
+}


### PR DESCRIPTION
# Please explain PR reason.
This is to resolve https://github.com/JustFly1984/react-google-maps-api/issues/10

It allows putting an InfoWindow as a child of a Marker, and having the infowindow automatically anchored to the marker.