### PR TITLE
Export map context

### DIFF
--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -75,4 +75,4 @@ export {
 
 export { default as Autocomplete, AutocompleteProps } from './components/places/Autocomplete'
 
-export { useGoogleMap } from './map-context'
+export { default as MapContext, useGoogleMap } from './map-context'


### PR DESCRIPTION
By exporting the `MapContext` it is possible to lift the context of the map up, allowing components to render map components without being a child of the `GoogleMap` component.

```tsx
...
const [myMap, setMyMap] = useState(null)

return (
  <Content>
    <GoogleMap onLoad={setMyMap} />
    <MapContext.provider value={myMap}>
      <Sidebar>
        <MyMarker />
      </SideBar>
    </MapContext>
  </Content>
)
...
```

This is currently very clunky to do, as you would have to save the map instance in a state and pass your own context around. But since the map components are looking for the `MapContext` by default, you would have to do something like

```tsx
<Marker onLoad={m => map && m.setMap(map)} />
```
This was discussed a bit here as well: https://github.com/JustFly1984/react-google-maps-api/issues/49

An alternative to this could also be to allow passing in a custom `ref` to `GoogleMap`, allowing us to mount the map itself on a child element...