### PR TITLE
Re-render icons on end of clustering cycle. 

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/Cluster.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/Cluster.tsx
@@ -141,8 +141,6 @@ export class Cluster {
       marker.setMap(null)
     }
 
-    this.updateIcon()
-
     return true
   }
 

--- a/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
@@ -709,7 +709,11 @@ export class Clusterer {
        * @param {Clusterer} mc The Clusterer whose markers are being clustered.
        * @event
        */
-      google.maps.event.trigger(this, 'clusteringend', this)
+      google.maps.event.trigger(this, 'clusteringend', this) 
+
+      for (let i = 0; i < this.clusters.length; i++) {
+        this.clusters[i].updateIcon()
+      }
     }
   }
 


### PR DESCRIPTION
Based on https://github.com/googlemaps/v3-utility-library/pull/613

I was using your library, with the clusterer, with lots of pins (around 10,000) and I noticed some slow behaviour when changing zoom levels. You could see all the clusters get built back up. I didn't see this with a different version of the clusterer, so I dug in and I found that that the original repo for the Google clusterer had a bugfix to only re-render the clusters at the end of clustering. This PR just pulls in that fix.