### PR TITLE
Added support for CSP nonces

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -15,6 +15,7 @@ interface LoadScriptState {
 
 export interface LoadScriptProps extends LoadScriptUrlOptions {
   id: string
+  nonce?: string
   loadingElement?: React.ReactNode
   onLoad?: () => void
   onError?: (error: Error) => void
@@ -179,6 +180,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
 
     const injectScriptOptions = {
       id: this.props.id,
+      nonce: this.props.nonce,
       url: makeLoadScriptUrl(this.props),
     }
 

--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -11,6 +11,7 @@ import { defaultLoadScriptProps } from './LoadScript'
 
 export interface UseLoadScriptOptions extends LoadScriptUrlOptions {
   id?: string
+  nonce?: string
   preventGoogleFontsLoading?: boolean
 }
 
@@ -19,6 +20,7 @@ let previouslyLoadedUrl: string
 export function useLoadScript({
   id = defaultLoadScriptProps.id,
   version = defaultLoadScriptProps.version,
+  nonce,
   googleMapsApiKey,
   googleMapsClientId,
   language,
@@ -91,7 +93,7 @@ export function useLoadScript({
         return
       }
 
-      injectScript({ id, url })
+      injectScript({ id, url, nonce })
         .then(setLoadedIfMounted)
         .catch(function handleInjectError(err) {
           if (isMounted.current) {
@@ -105,7 +107,7 @@ export function useLoadScript({
           console.error(err)
         })
     },
-    [id, url]
+    [id, url, nonce]
   )
 
   const prevLibraries = React.useRef<undefined | string[]>()

--- a/packages/react-google-maps-api/src/utils/injectscript.ts
+++ b/packages/react-google-maps-api/src/utils/injectscript.ts
@@ -7,9 +7,10 @@ interface WindowWithGoogleMap extends Window {
 interface InjectScriptArg {
   url: string
   id: string
+  nonce?: string
 }
 
-export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
+export const injectScript = ({ url, id, nonce }: InjectScriptArg): Promise<any> => {
   if (!isBrowser) {
     return Promise.reject(new Error('document is undefined'))
   }
@@ -58,6 +59,7 @@ export const injectScript = ({ url, id }: InjectScriptArg): Promise<any> => {
     script.src = url
     script.id = id
     script.async = true
+    script.nonce = nonce
     script.onerror = function onerror(err): void {
       script.setAttribute('data-state', 'error')
       reject(err)


### PR DESCRIPTION
Added support for Content Security Policy nonces. This PR makes it possible to provide a nonce to, for example, the `useLoadScript` hooks. The changes in this PR will propagate the nonce to the `injectScript` function which will load the Google Maps javascript. 

Background information: 

https://conference.hitb.org/hitbsecconf2017ams/materials/D1T1%20-%20Michele%20Spagnuolo%20and%20Lukas%20Wilschelbaum%20-%20So%20We%20Broke%20All%20CSPS.pdf