### PR TITLE
Accessibility: add empty alt text to 'x' icon image in InfoWindow

### DIFF
--- a/packages/react-google-maps-api-infobox/src/InfoBox.tsx
+++ b/packages/react-google-maps-api-infobox/src/InfoBox.tsx
@@ -187,7 +187,7 @@ export class InfoBox {
     let img = ''
 
     if (this.closeBoxURL !== '') {
-      img = '<img'
+      img = '<img alt=""'
       img += " src='" + this.closeBoxURL + "'"
       img += ' align=right' // Do this because Opera chokes on style='float: right;'
       img += " style='"

--- a/packages/react-google-maps-api-infobox/src/InfoBox.tsx
+++ b/packages/react-google-maps-api-infobox/src/InfoBox.tsx
@@ -188,6 +188,7 @@ export class InfoBox {
 
     if (this.closeBoxURL !== '') {
       img = '<img alt=""'
+      img += ' aria-hidden="true"'
       img += " src='" + this.closeBoxURL + "'"
       img += ' align=right' // Do this because Opera chokes on style='float: right;'
       img += " style='"


### PR DESCRIPTION
This one-line change addresses an accessibility violation for screen readers, in that the image used for the 'x' icon in the `InfoWindow` lacks alt text. 

The alt is now an empty string due to the image being decorative rather than informative, as the image is already wrapped in a `<button>` with `aria-label="Close"`
