### PR TITLE
fix: allow loadScript to check for window.google.maps intead of windo…

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -42,14 +42,14 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
   }
 
   cleanupCallback = (): void => {
-    delete window.google
+    delete window.google.maps
 
     this.injectScript()
   }
 
   componentDidMount(): void {
     if (isBrowser) {
-      if (window.google && !cleaningUp) {
+      if (window.google && window.google.maps && !cleaningUp) {
         console.error('google api is already presented')
 
         return
@@ -206,7 +206,7 @@ class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {
         console.error(`
           There has been an Error with loading Google Maps API script, please check that you provided correct google API key (${this
             .props.googleMapsApiKey || '-'}) or Client ID (${this.props.googleMapsClientId ||
-          '-'}) to <LoadScript />
+            '-'}) to <LoadScript />
           Otherwise it is a Network issue.
         `)
       })

--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -88,7 +88,7 @@ export function useLoadScript({
         }
       }
 
-      if (window.google && previouslyLoadedUrl === url) {
+      if (window.google && window.google.maps && previouslyLoadedUrl === url) {
         setLoadedIfMounted()
         return
       }


### PR DESCRIPTION
…w.google

# Please explain PR reason
Google's One Tap sign-in uses the `window.google` object to store account information. This library does not work when using One Tap because it thinks that the library is already loaded since this library only checks for `window.google`. So I've made a modification to check for `window.google.maps` instead. 