### PR TITLE
Make Autocomplete.tsx stylable

### DIFF
--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -59,6 +59,7 @@ export interface AutocompleteProps {
   onLoad?: (autocomplete: google.maps.places.Autocomplete) => void
   /** This callback is called when the component unmounts. It is called with the autocomplete instance. */
   onUnmount?: (autocomplete: google.maps.places.Autocomplete) => void
+  [key: string]: any
 }
 
 export class Autocomplete extends React.PureComponent<AutocompleteProps, AutocompleteState> {
@@ -127,7 +128,7 @@ export class Autocomplete extends React.PureComponent<AutocompleteProps, Autocom
   }
 
   render(): React.ReactNode {
-    return <div ref={this.containerElement}>{React.Children.only(this.props.children)}</div>
+    return <div ref={this.containerElement} {...this.props}>{React.Children.only(this.props.children)}</div>
   }
 }
 

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -59,7 +59,7 @@ export interface AutocompleteProps {
   onLoad?: (autocomplete: google.maps.places.Autocomplete) => void
   /** This callback is called when the component unmounts. It is called with the autocomplete instance. */
   onUnmount?: (autocomplete: google.maps.places.Autocomplete) => void
-  [key: string]: any
+  className?: string
 }
 
 export class Autocomplete extends React.PureComponent<AutocompleteProps, AutocompleteState> {
@@ -128,7 +128,7 @@ export class Autocomplete extends React.PureComponent<AutocompleteProps, Autocom
   }
 
   render(): React.ReactNode {
-    return <div ref={this.containerElement} {...this.props}>{React.Children.only(this.props.children)}</div>
+    return <div ref={this.containerElement} className={this.props.className || ''}>{React.Children.only(this.props.children)}</div>
   }
 }
 


### PR DESCRIPTION
Currently the autocomplete ref is a div that is not styleable.
This changes should add this option.

Were not able to set up locally. Please test it.

Fixes #201 