### PR TITLE
Position equality helper for overlayview

### DIFF
--- a/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.tsx
@@ -5,7 +5,7 @@ import invariant from 'invariant'
 
 import MapContext from '../../map-context'
 
-import { getOffsetOverride, getLayoutStyles } from './dom-helper'
+import { getOffsetOverride, getLayoutStyles, arePositionsEqual } from './dom-helper'
 
 interface OverlayViewState {
   paneEl: Element | null
@@ -114,12 +114,15 @@ export class OverlayView extends React.PureComponent<OverlayViewProps, OverlayVi
       this.props.position
     )
 
-    this.setState({
-      containerStyle: {
-        ...layoutStyles,
-        position: 'absolute'
-      },
-    })
+    const { left, top, width, height } = this.state.containerStyle;
+    if(!arePositionsEqual(layoutStyles, { left, top, width, height })) {
+      this.setState({
+        containerStyle: {
+          ...layoutStyles,
+          position: 'absolute'
+        },
+      })
+    }
   }
 
   draw = (): void => {

--- a/packages/react-google-maps-api/src/components/dom/dom-helper.ts
+++ b/packages/react-google-maps-api/src/components/dom/dom-helper.ts
@@ -1,3 +1,5 @@
+import { PositionDrawProps } from "../../types"
+
 /* eslint-disable filenames/match-regex */
 export function getOffsetOverride(
   containerElement: HTMLElement,
@@ -74,7 +76,7 @@ export const getLayoutStyles = (
   offset: { x: number; y: number },
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral,
   position?: google.maps.LatLng | google.maps.LatLngLiteral
-): { left: string; top: string; width?: string; height?: string } => {
+): PositionDrawProps => {
   return bounds !== undefined
     ? getLayoutStylesByBounds(
         mapCanvasProjection,
@@ -86,4 +88,14 @@ export const getLayoutStyles = (
         offset,
         ensureOfType(position, google.maps.LatLng, createLatLng)
       )
+}
+
+export const arePositionsEqual = (
+  currentPosition: PositionDrawProps,
+  previousPosition: PositionDrawProps
+): boolean => {
+  return currentPosition.left === previousPosition.left
+    && currentPosition.top === previousPosition.top
+    && currentPosition.width === previousPosition.height
+    && currentPosition.height === previousPosition.height;
 }

--- a/packages/react-google-maps-api/src/types.tsx
+++ b/packages/react-google-maps-api/src/types.tsx
@@ -1,3 +1,10 @@
 export interface HasMarkerAnchor {
   anchor?: google.maps.Marker | null
 }
+
+export interface PositionDrawProps {
+  left?: string | number;
+  top?: string | number;
+  width?: string | number;
+  height?: string | number;
+}


### PR DESCRIPTION
This fixes panning re-rendering OverlayView component causing performance issues with a larger set of complex custom markers.
https://react-google-maps-api-docs.netlify.app/#overlayview

Examples in our application:
![after](https://user-images.githubusercontent.com/41839786/92649855-5332c680-f2f4-11ea-98e2-7d5565e54919.gif)
![before](https://user-images.githubusercontent.com/41839786/92649858-5463f380-f2f4-11ea-97b9-3568c5a7460a.gif)
