### PR TITLE
Support map ids for vector maps

### DIFF
--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -28,6 +28,7 @@ export function useLoadScript({
   libraries,
   preventGoogleFontsLoading,
   channel,
+  mapIds,
 }: UseLoadScriptOptions): {
   isLoaded: boolean
   loadError: Error | undefined
@@ -73,6 +74,7 @@ export function useLoadScript({
     region,
     libraries,
     channel,
+    mapIds
   })
 
   React.useEffect(

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -8,6 +8,7 @@ export interface LoadScriptUrlOptions {
   region?: string
   libraries?: string[]
   channel?: string
+  mapIds?: string[]
 }
 
 export function makeLoadScriptUrl({
@@ -18,6 +19,7 @@ export function makeLoadScriptUrl({
   region,
   libraries,
   channel,
+  mapIds
 }: LoadScriptUrlOptions): string {
   const params = []
 
@@ -50,6 +52,10 @@ export function makeLoadScriptUrl({
 
   if (channel) {
     params.push(`channel=${channel}`)
+  }
+
+  if (mapIds && mapIds.length) {
+    params.push(`map_ids=${mapIds.join(',')}`)
   }
 
   params.push('callback=initMap')


### PR DESCRIPTION
Google now supports using vector maps instead of raster (in beta), see https://developers.google.com/maps/documentation/javascript/vector-map :tada: 

In order to support this, the load script url needs to include the available map ids.

Additionally, the `MapOptions` should include the specific `mapId`, however the official types are not yet updated, as evident from their own examples [here](https://github.com/googlemaps/js-samples/blob/25a4ff9635382931e19cb723b3c9460076af1d0e/samples/vector-use-static-map/src/index.ts#L43).

However, since all the option props from the `GoogleMap` component are applied, we can just use
```ts
<GoogleMap
  onLoad={onMapMount}
  options={{ mapId: '...' } as google.maps.MapOptions }
/>
```
and wait for the official types to get updated.

I've tested it, and it works pretty well. 

![image](https://user-images.githubusercontent.com/1812228/94435821-ec3e5a00-019b-11eb-9b1f-78404d27db3b.png)
