### PR TITLE
Add ClusterIcon CSS Class From ClusterIconStyle

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -316,7 +316,8 @@ export class ClusterIcon {
     this.height = style.height
     this.width = style.width
 
-    this.className = `${this.className} ${style.className}`
+    if (style.className)
+      this.className = `${this.className} ${style.className}`
 
     this.anchorText = style.anchorText || [0, 0]
     this.anchorIcon = style.anchorIcon || [this.height / 2, this.width / 2]

--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -315,6 +315,9 @@ export class ClusterIcon {
     this.url = style.url
     this.height = style.height
     this.width = style.width
+
+    this.className = `${this.className} ${style.className}`
+
     this.anchorText = style.anchorText || [0, 0]
     this.anchorIcon = style.anchorIcon || [this.height / 2, this.width / 2]
 

--- a/packages/react-google-maps-api-marker-clusterer/src/types.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/types.tsx
@@ -32,9 +32,9 @@ export interface ClustererOptions {
 
 export interface ClusterIconStyle {
   url: string
+  className?: string
   height: number
   width: number
-  className: string
   anchorText?: number[]
   anchorIcon?: number[]
   textColor?: string

--- a/packages/react-google-maps-api-marker-clusterer/src/types.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/types.tsx
@@ -34,6 +34,7 @@ export interface ClusterIconStyle {
   url: string
   height: number
   width: number
+  className: string
   anchorText?: number[]
   anchorIcon?: number[]
   textColor?: string


### PR DESCRIPTION
This pull request adds the ability to set the CSS class of a cluster from the cluster style.

This was modeled after the Google Maps JavaScript MarkerClustererPlus Advanced example:
- [Interactive example](https://googlemaps.github.io/js-markerclustererplus/examples/advanced_example.html)
- [Code for CSS only style](https://github.com/googlemaps/js-markerclustererplus/blob/aca45766bcb5065153592a34c3f99fa7bf5b898b/examples/advanced_example.html#L177)

Here is how the className property is [set in Google's `useStyle()`](https://github.com/googlemaps/js-markerclustererplus/blob/aca45766bcb5065153592a34c3f99fa7bf5b898b/src/cluster-icon.ts#L412).

This will allow users to have more control over the classes for each of the clusters, enabling them to use a CSS only approach to clustering.