### PR TITLE
changed default version for load script to quarterly #1776

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -29,7 +29,7 @@ export function DefaultLoadingElement(): JSX.Element {
 
 export const defaultLoadScriptProps = {
   id: 'script-loader',
-  version: 'weekly',
+  version: 'quarterly',
 }
 
 class LoadScript extends React.PureComponent<LoadScriptProps, LoadScriptState> {


### PR DESCRIPTION
For a more stable map loading we could change the default **weekly** to a more predictable version like **quarterly**

> The quarterly channel is specified with v=quarterly.
> This channel is updated once per quarter, and is the most predictable.

[Source](https://developers.google.com/maps/documentation/javascript/versions)