### PR TITLE
Allow react v17 as peer dependencies

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -90,8 +90,8 @@
     "invariant": "2.2.4"
   },
   "peerDependencies": {
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3"
+    "react": "^16.6.3 || ^17.0.0",
+    "react-dom": "^16.6.3 || ^17.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "11.0.4",


### PR DESCRIPTION
### Please explain PR reason

Related to #1684 

It is to allow react 17 as a peer dependencies. This version of react should (in theory) not break anything. At work we are currently on react 17 and we've add no issue related to it.
