### PR TITLE
Fix CALCULATOR in Clusterer

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/jest.config.js
+++ b/packages/react-google-maps-api-marker-clusterer/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  "roots": [
+    "<rootDir>/src"
+  ],
+  "transform": {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.tsx?$",
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ],
+  "setupFilesAfterEnv": ["<rootDir>/src/setup-tests.js"]
+}

--- a/packages/react-google-maps-api-marker-clusterer/package.json
+++ b/packages/react-google-maps-api-marker-clusterer/package.json
@@ -53,7 +53,6 @@
     "@getify/eslint-plugin-proper-arrows": "10.0.0",
     "@types/babel-types": "7.0.9",
     "@types/googlemaps": "3.43.2",
-    "@types/jest": "26.0.20",
     "@types/react-dom": "17.0.0",
     "@typescript-eslint/eslint-plugin": "4.14.1",
     "@typescript-eslint/parser": "4.14.1",
@@ -84,7 +83,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "rimraf": "3.0.2",
-    "ts-jest": "^26.5.6",
+    "ts-jest": "26.4.4",
     "tsdx": "0.14.1",
     "typescript": "4.1.3",
     "webpack": "5.17.0"

--- a/packages/react-google-maps-api-marker-clusterer/package.json
+++ b/packages/react-google-maps-api-marker-clusterer/package.json
@@ -45,6 +45,7 @@
     "lint": "npx eslint ./src/**/*.{ts,tsx}",
     "pub": "yarn publish .",
     "tc": "tsc -p ./tsconfig.json --noEmit --traceResolution",
+    "test": "jest",
     "prepublishOnly": "yarn build"
   },
   "dependencies": {},
@@ -52,6 +53,7 @@
     "@getify/eslint-plugin-proper-arrows": "10.0.0",
     "@types/babel-types": "7.0.9",
     "@types/googlemaps": "3.43.2",
+    "@types/jest": "26.0.20",
     "@types/react-dom": "17.0.0",
     "@typescript-eslint/eslint-plugin": "4.14.1",
     "@typescript-eslint/parser": "4.14.1",
@@ -82,7 +84,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "rimraf": "3.0.2",
-    "ts-jest": "26.4.4",
+    "ts-jest": "^26.5.6",
     "tsdx": "0.14.1",
     "typescript": "4.1.3",
     "webpack": "5.17.0"

--- a/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
@@ -11,7 +11,8 @@ import {
 } from './types'
 
 /**
- * Supports 1 - 9007199254740991 (Number.MAX_SAFE_INTEGER) markers
+ * Supports up to 9007199254740991 (Number.MAX_SAFE_INTEGER) markers
+ * which is not a problem as max array length is 4294967296 (2**32)
  */
 const CALCULATOR = function CALCULATOR(
   markers: MarkerExtended[],

--- a/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/Clusterer.tsx
@@ -10,32 +10,23 @@ import {
   ClusterIconInfo,
 } from './types'
 
+/**
+ * Supports 1 - 9007199254740991 (Number.MAX_SAFE_INTEGER) markers
+ */
 const CALCULATOR = function CALCULATOR(
   markers: MarkerExtended[],
   numStyles: number
 ): ClusterIconInfo {
-  let index = 0
+  const count = markers.length
 
-  const title = ''
+  const numberOfDigits = count.toString().length
 
-  const count = markers.length.toString()
-
-  let dv: string | number = count
-
-  while (dv !== 0) {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
-    dv = parseInt(dv, 10) / 10
-
-    index++
-  }
-
-  index = Math.min(index, numStyles)
+  const index = Math.min(numberOfDigits, numStyles)
 
   return {
-    text: count,
+    text: count.toString(),
     index: index,
-    title: title,
+    title: '',
   }
 }
 

--- a/packages/react-google-maps-api-marker-clusterer/src/__tests__/clusterer.test.ts
+++ b/packages/react-google-maps-api-marker-clusterer/src/__tests__/clusterer.test.ts
@@ -9,7 +9,19 @@ describe('Clusterer', () => {
     const clusterer = new Clusterer(mapMock)
     const { calculator } = clusterer
 
-    it('should return index 1 for 1-digit number of markers', () => {
+    it('should return index 1 for no markers', () => {
+      const markers: google.maps.Marker[] = []
+      const numStyles = 10
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '0',
+        index: 1,
+        title: '',
+      })
+    })
+
+    it('should return index 1 for single marker', () => {
       const markers = [markerMock]
       const numStyles = 10
       const actual = calculator(markers, numStyles)
@@ -21,9 +33,21 @@ describe('Clusterer', () => {
       })
     })
 
+    it('should return index 1 for 1-digit number of markers', () => {
+      const markers = Array.from({ length: 9 }, () => markerMock)
+      const numStyles = 10
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '9',
+        index: 1,
+        title: '',
+      })
+    })
+
     it('should return index 2 for 2-digit number of markers', () => {
       const markers = Array.from({ length: 99 }, () => markerMock)
-      const numStyles = 10
+      const numStyles = 50
       const actual = calculator(markers, numStyles)
 
       expect(actual).toEqual({

--- a/packages/react-google-maps-api-marker-clusterer/src/__tests__/clusterer.test.ts
+++ b/packages/react-google-maps-api-marker-clusterer/src/__tests__/clusterer.test.ts
@@ -1,0 +1,60 @@
+import { Clusterer } from '../Clusterer'
+
+describe('Clusterer', () => {
+  describe('CALCULATOR', () => {
+    const elementMock = document.createElement('div')
+    const mapMock = new window.google.maps.Map(elementMock)
+    const markerMock = new google.maps.Marker()
+
+    const clusterer = new Clusterer(mapMock)
+    const { calculator } = clusterer
+
+    it('should return index 1 for 1-digit number of markers', () => {
+      const markers = [markerMock]
+      const numStyles = 10
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '1',
+        index: 1,
+        title: '',
+      })
+    })
+
+    it('should return index 2 for 2-digit number of markers', () => {
+      const markers = Array.from({ length: 99 }, () => markerMock)
+      const numStyles = 10
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '99',
+        index: 2,
+        title: '',
+      })
+    })
+
+    it('should return index 3 for 3-digit number of markers', () => {
+      const markers = Array.from({ length: 125 }, () => markerMock)
+      const numStyles = 10
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '125',
+        index: 3,
+        title: '',
+      })
+    })
+
+    it('should return index = numStyles if it is smaller than calculated index', () => {
+      const markers = Array.from({ length: 10_000 }, () => markerMock)
+      const numStyles = 3
+      const actual = calculator(markers, numStyles)
+
+      expect(actual).toEqual({
+        text: '10000',
+        index: 3,
+        title: '',
+      })
+    })
+  })
+})

--- a/packages/react-google-maps-api-marker-clusterer/src/setup-tests.js
+++ b/packages/react-google-maps-api-marker-clusterer/src/setup-tests.js
@@ -1,0 +1,356 @@
+const createMockFuncsFromArray = (instance, names = []) => {
+  names.forEach(name => {
+    instance[name] = jest.fn().mockName(name)
+  })
+}
+
+const createGoogleMapsMock = (libraries = []) => {
+  const createMVCObject = instance => {
+    const listeners = {}
+    instance.listeners = listeners
+
+    instance.addListener = jest
+      .fn((event, fn) => {
+        listeners[event] = listeners[event] || []
+        listeners[event].push(fn)
+        return {
+          remove: () => {
+            const index = listeners[event].indexOf(fn)
+
+            if (index !== -1) {
+              listeners[event].splice(index, 1)
+            }
+          },
+        }
+      })
+      .mockName('addListener')
+
+    createMockFuncsFromArray(instance, [
+      'bindTo',
+      'get',
+      'notify',
+      'set',
+      'setValues',
+      'unbind',
+      'unbindAll',
+    ])
+  }
+
+  const OverlayViewMock = function() {}
+  OverlayViewMock.prototype.setMap = jest.fn()
+
+  const maps = {
+    Animation: {
+      BOUNCE: 1,
+      DROP: 2,
+      Lo: 3,
+      Go: 4,
+    },
+    BicyclingLayer: jest.fn().mockImplementation(function() {
+      createMVCObject(this)
+      createMockFuncsFromArray(this, ['setMap'])
+    }),
+    TransitLayer: jest.fn().mockImplementation(function() {
+      createMVCObject(this)
+      createMockFuncsFromArray(this, ['setMap'])
+    }),
+    Circle: jest.fn().mockImplementation(function(opts) {
+      this.opts = opts
+      createMVCObject(this)
+      createMockFuncsFromArray(this, [
+        'setCenter',
+        'setDraggable',
+        'setEditable',
+        'setMap',
+        'setOptions',
+        'setRadius',
+        'setVisible',
+      ])
+    }),
+    ControlPosition: {
+      TOP_LEFT: 1,
+      TOP_CENTER: 2,
+      TOP: 2,
+      TOP_RIGHT: 3,
+      LEFT_CENTER: 4,
+      LEFT: 5,
+      LEFT_TOP: 5,
+      LEFT_BOTTOM: 6,
+      RIGHT: 7,
+      RIGHT_CENTER: 8,
+      RIGHT_BOTTOM: 9,
+      BOTTOM_LEFT: 10,
+      BOTTOM: 11,
+      BOTTOM_CENTER: 11,
+      BOTTOM_RIGHT: 12,
+      CENTER: 13,
+    },
+    Data: jest.fn().mockImplementation(function(options) {
+      this.options = options
+      createMVCObject(this)
+      createMockFuncsFromArray(this, [
+        'setControlPosition',
+        'setControls',
+        'setDrawingMode',
+        'setMap',
+        'setStyle',
+      ])
+    }),
+    DirectionsRenderer: jest.fn().mockImplementation(function(opts) {
+      this.opts = opts
+      createMVCObject(this)
+      createMockFuncsFromArray(this, [
+        'setDirections',
+        'setMap',
+        'setOptions',
+        'setPanel',
+        'setRouteIndex',
+      ])
+    }),
+    DirectionsService: function() {},
+    DirectionsStatus: {
+      INVALID_REQUEST: 'INVALID_REQUEST',
+      MAX_WAYPOINTS_EXCEEDED: 'MAX_WAYPOINTS_EXCEEDED',
+      NOT_FOUND: 'NOT_FOUND',
+      OK: 'OK',
+      OVER_QUERY_LIMIT: 'OVER_QUERY_LIMIT',
+      REQUEST_DENIED: 'REQUEST_DENIED',
+      UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+      ZERO_RESULTS: 'ZERO_RESULTS',
+    },
+    DirectionsTravelMode: {
+      BICYCLING: 'BICYCLING',
+      DRIVING: 'DRIVING',
+      TRANSIT: 'TRANSIT',
+      WALKING: 'WALKING',
+    },
+    DirectionsUnitSystem: {
+      IMPERIAL: 1,
+      METRIC: 0,
+    },
+    DistanceMatrixElementStatus: {
+      NOT_FOUND: 'NOT_FOUND',
+      OK: 'OK',
+      ZERO_RESULTS: 'ZERO_RESULTS',
+    },
+    DistanceMatrixService: function() {},
+    DistanceMatrixStatus: {
+      INVALID_REQUEST: 'INVALID_REQUEST',
+      MAX_DIMENSIONS_EXCEEDED: 'MAX_DIMENSIONS_EXCEEDED',
+      MAX_ELEMENTS_EXCEEDED: 'MAX_ELEMENTS_EXCEEDED',
+      OK: 'OK',
+      OVER_QUERY_LIMIT: 'OVER_QUERY_LIMIT',
+      REQUEST_DENIED: 'REQUEST_DENIED',
+      UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+    },
+    ElevationService: function() {},
+    ElevationStatus: {
+      Co: 'DATA_NOT_AVAILABLE',
+      INVALID_REQUEST: 'INVALID_REQUEST',
+      OK: 'OK',
+      OVER_QUERY_LIMIT: 'OVER_QUERY_LIMIT',
+      REQUEST_DENIED: 'REQUEST_DENIED',
+      UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+    },
+    FusionTablesLayer: jest.fn().mockImplementation(function(options) {
+      this.options = options
+      createMVCObject(this)
+      createMockFuncsFromArray(this, ['setMap', 'setOptions'])
+    }),
+    Geocoder: function() {},
+    GeocoderLocationType: {
+      APPROXIMATE: 'APPROXIMATE',
+      GEOMETRIC_CENTER: 'GEOMETRIC_CENTER',
+      RANGE_INTERPOLATED: 'RANGE_INTERPOLATED',
+      ROOFTOP: 'ROOFTOP',
+    },
+    GeocoderStatus: {
+      ERROR: 'ERROR',
+      INVALID_REQUEST: 'INVALID_REQUEST',
+      OK: 'OK',
+      OVER_QUERY_LIMIT: 'OVER_QUERY_LIMIT',
+      REQUEST_DENIED: 'REQUEST_DENIED',
+      UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+      ZERO_RESULTS: 'ZERO_RESULTS',
+    },
+    GroundOverlay: function() {},
+    ImageMapType: function() {},
+    InfoWindow: function() {},
+    KmlLayer: function() {},
+    KmlLayerStatus: {
+      DOCUMENT_NOT_FOUND: 'DOCUMENT_NOT_FOUND',
+      DOCUMENT_TOO_LARGE: 'DOCUMENT_TOO_LARGE',
+      FETCH_ERROR: 'FETCH_ERROR',
+      INVALID_DOCUMENT: 'INVALID_DOCUMENT',
+      INVALID_REQUEST: 'INVALID_REQUEST',
+      LIMITS_EXCEEDED: 'LIMITS_EXCEEDED',
+      OK: 'OK',
+      TIMED_OUT: 'TIMED_OUT',
+      UNKNOWN: 'UNKNOWN',
+    },
+    LatLng: function() {},
+    LatLngBounds: function() {},
+    MVCArray: function() {},
+    MVCObject: jest.fn().mockImplementation(function() {
+      createMVCObject(this)
+    }),
+    Map: jest.fn().mockImplementation(function(mapDiv, opts) {
+      this.mapDiv = mapDiv
+      this.opts = opts
+      createMVCObject(this)
+      createMockFuncsFromArray(this, [
+        'setCenter',
+        'setClickableIcons',
+        'setHeading',
+        'setMapTypeId',
+        'setOptions',
+        'setStreetView',
+        'setTilt',
+        'setZoom',
+        'fitBounds',
+        'getBounds',
+        'panToBounds',
+      ])
+    }),
+    MapTypeControlStyle: {
+      DEFAULT: 0,
+      DROPDOWN_MENU: 2,
+      HORIZONTAL_BAR: 1,
+      INSET: 3,
+      INSET_LARGE: 4,
+    },
+    MapTypeId: {
+      HYBRID: 'hybrid',
+      ROADMAP: 'roadmap',
+      SATELLITE: 'satellite',
+      TERRAIN: 'terrain',
+    },
+    MapTypeRegistry: function() {},
+    Marker: jest.fn().mockImplementation(function(opts) {
+      this.opts = opts
+      createMVCObject(this)
+      createMockFuncsFromArray(this, [
+        'setMap',
+        'setOpacity',
+        'setOptions',
+        'setPosition',
+        'setShape',
+        'setTitle',
+        'setVisible',
+        'setZIndex',
+      ])
+    }),
+    MarkerImage: function() {},
+    MaxZoomService: function() {
+      return {
+        getMaxZoomAtLatLng: function() {},
+      }
+    },
+    MaxZoomStatus: {
+      ERROR: 'ERROR',
+      OK: 'OK',
+    },
+    NavigationControlStyle: {
+      ANDROID: 2,
+      DEFAULT: 0,
+      Mo: 4,
+      SMALL: 1,
+      ZOOM_PAN: 3,
+      ik: 5,
+    },
+    OverlayView: OverlayViewMock,
+    Point: function() {},
+    Polygon: function() {},
+    Polyline: function() {},
+    Rectangle: function() {},
+    SaveWidget: function() {},
+    ScaleControlStyle: {
+      DEFAULT: 0,
+    },
+    Size: function() {},
+    StreetViewCoverageLayer: function() {},
+    StreetViewPanorama: function() {},
+    StreetViewPreference: {
+      BEST: 'best',
+      NEAREST: 'nearest',
+    },
+    StreetViewService: function() {},
+    StreetViewSource: {
+      DEFAULT: 'default',
+      OUTDOOR: 'outdoor',
+    },
+    StreetViewStatus: {
+      OK: 'OK',
+      UNKNOWN_ERROR: 'UNKNOWN_ERROR',
+      ZERO_RESULTS: 'ZERO_RESULTS',
+    },
+    StrokePosition: {
+      CENTER: 0,
+      INSIDE: 1,
+      OUTSIDE: 2,
+    },
+    StyledMapType: function() {},
+    SymbolPath: {
+      BACKWARD_CLOSED_ARROW: 3,
+      BACKWARD_OPEN_ARROW: 4,
+      CIRCLE: 0,
+      FORWARD_CLOSED_ARROW: 1,
+      FORWARD_OPEN_ARROW: 2,
+    },
+    TrafficLayer: jest.fn().mockImplementation(function(opts) {
+      this.opts = opts
+      createMVCObject(this)
+      createMockFuncsFromArray(this, ['setMap', 'setOptions'])
+    }),
+    TrafficModel: {
+      BEST_GUESS: 'bestguess',
+      OPTIMISTIC: 'optimistic',
+      PESSIMISTIC: 'pessimistic',
+    },
+    TransitMode: {
+      BUS: 'BUS',
+      RAIL: 'RAIL',
+      SUBWAY: 'SUBWAY',
+      TRAIN: 'TRAIN',
+      TRAM: 'TRAM',
+    },
+    TransitRoutePreference: {
+      FEWER_TRANSFERS: 'FEWER_TRANSFERS',
+      LESS_WALKING: 'LESS_WALKING',
+    },
+    TravelMode: {
+      BICYCLING: 'BICYCLING',
+      DRIVING: 'DRIVING',
+      TRANSIT: 'TRANSIT',
+      WALKING: 'WALKING',
+    },
+    UnitSystem: {
+      IMPERIAL: 1,
+      METRIC: 0,
+    },
+    ZoomControlStyle: {
+      DEFAULT: 0,
+      LARGE: 2,
+      SMALL: 1,
+      ik: 3,
+    },
+    __gjsload__: function() {},
+    event: {
+      clearInstanceListeners: jest.fn().mockName('clearInstanceListeners'),
+    },
+  }
+
+  if (libraries.includes('places')) {
+    maps.places = {
+      AutocompleteService: jest.fn(() => ({
+        getPlacePredictions: jest.fn(),
+      })),
+    }
+  }
+
+  return maps
+}
+
+window.google = {
+  maps: createGoogleMapsMock(),
+}

--- a/packages/react-google-maps-api-marker-clusterer/yarn.lock
+++ b/packages/react-google-maps-api-marker-clusterer/yarn.lock
@@ -1472,10 +1472,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.20":
-  version "26.0.20"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
-  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+"@types/jest@26.x":
+  version "26.0.23"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.23.tgz#a1b7eab3c503b80451d019efb588ec63522ee4e7"
+  integrity sha512-ZHLmWMJ9jJ9PTiT58juykZpL7KjwJywFN3Rr2pTSkyQfydf/rk22yS7W8p5DaVUMQ2BQC7oYiU3FjbTM/mYrOA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -5660,11 +5660,6 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
-lodash@4.x:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -7588,6 +7583,23 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
+ts-jest@26.4.4:
+  version "26.4.4"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
+  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
+  dependencies:
+    "@types/jest" "26.x"
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash.memoize "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
+
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
@@ -7603,22 +7615,6 @@ ts-jest@^25.3.1:
     mkdirp "0.x"
     semver "6.x"
     yargs-parser "18.x"
-
-ts-jest@^26.5.6:
-  version "26.5.6"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
-  integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
-  dependencies:
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^26.1.0"
-    json5 "2.x"
-    lodash "4.x"
-    make-error "1.x"
-    mkdirp "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"

--- a/packages/react-google-maps-api-marker-clusterer/yarn.lock
+++ b/packages/react-google-maps-api-marker-clusterer/yarn.lock
@@ -1472,10 +1472,10 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x":
-  version "26.0.15"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.15.tgz#12e02c0372ad0548e07b9f4e19132b834cb1effe"
-  integrity sha512-s2VMReFXRg9XXxV+CW9e5Nz8fH2K1aEhwgjUqPPbQd7g95T0laAcvLv032EhFHIa5GHsZ8W7iJEQVaJq6k3Gog==
+"@types/jest@26.0.20":
+  version "26.0.20"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
+  integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
   dependencies:
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
@@ -5660,6 +5660,11 @@ lodash.upperfirst@4.3.1:
   resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
   integrity sha1-E2Xt9DFIBIHvDRxolXpe2Z1J984=
 
+lodash@4.x:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
@@ -7583,23 +7588,6 @@ tr46@^2.0.2:
   dependencies:
     punycode "^2.1.1"
 
-ts-jest@26.4.4:
-  version "26.4.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.4.tgz#61f13fb21ab400853c532270e52cc0ed7e502c49"
-  integrity sha512-3lFWKbLxJm34QxyVNNCgXX1u4o/RV0myvA2y2Bxm46iGIjKlaY0own9gIckbjZJPn+WaJEnfPPJ20HHGpoq4yg==
-  dependencies:
-    "@types/jest" "26.x"
-    bs-logger "0.x"
-    buffer-from "1.x"
-    fast-json-stable-stringify "2.x"
-    jest-util "^26.1.0"
-    json5 "2.x"
-    lodash.memoize "4.x"
-    make-error "1.x"
-    mkdirp "1.x"
-    semver "7.x"
-    yargs-parser "20.x"
-
 ts-jest@^25.3.1:
   version "25.5.1"
   resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.5.1.tgz#2913afd08f28385d54f2f4e828be4d261f4337c7"
@@ -7615,6 +7603,22 @@ ts-jest@^25.3.1:
     mkdirp "0.x"
     semver "6.x"
     yargs-parser "18.x"
+
+ts-jest@^26.5.6:
+  version "26.5.6"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.5.6.tgz#c32e0746425274e1dfe333f43cd3c800e014ec35"
+  integrity sha512-rua+rCP8DxpA8b4DQD/6X2HQS8Zy/xzViVYfEs2OQu68tkCuKLV0Md8pmX55+W24uRIyAsf/BajRfxOs+R2MKA==
+  dependencies:
+    bs-logger "0.x"
+    buffer-from "1.x"
+    fast-json-stable-stringify "2.x"
+    jest-util "^26.1.0"
+    json5 "2.x"
+    lodash "4.x"
+    make-error "1.x"
+    mkdirp "1.x"
+    semver "7.x"
+    yargs-parser "20.x"
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"


### PR DESCRIPTION
### BREAKING CHANGE

Documentation says that for 125 markers index 3 is returned
> The styles array element used has an index of index minus 1. For example, the default calculator returns a text value of "125" and an index of **3** for a cluster icon representing 125 markers so the element used in the styles array is 2.

Unfortunately current code returns index 4

Code:
```javascript
const CALCULATOR = function CALCULATOR(
  markers: MarkerExtended[],
  numStyles: number
): ClusterIconInfo {
  let index = 0

  const title = ''

  const count = markers.length.toString()

  let dv: string | number = count

  while (dv !== 0) {
    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
    // @ts-ignore
    dv = parseInt(dv, 10) / 10

    index++
  }

  index = Math.min(index, numStyles)

  return {
    text: count,
    index: index,
    title: title,
  }
}
```

```javascript
CALCULATOR(Array.from({ length: 125 }), 10)
// {text: "125", index: 4, title: ""}