### PR TITLE
Add onMouseDown, onMouseUp event props

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -104,6 +104,10 @@ export interface GoogleMapProps {
   onMouseOut?: (e: google.maps.MapMouseEvent) => void
   /** This event is fired when the user's mouse enters the map container. */
   onMouseOver?: (e: google.maps.MapMouseEvent) => void
+  /** This event is fired when the DOM mousedown event is fired on the map container. */
+  onMouseDown?: (e: google.maps.MapMouseEvent) => void
+  /** This event is fired when the DOM mouseup event is fired on the map container. */
+  onMouseUp?: (e: google.maps.MapMouseEvent) => void
   /** This event is fired when the DOM contextmenu event is fired on the map container. */
   onRightClick?: (e: google.maps.MapMouseEvent) => void
   /** This event is fired when the visible tiles have finished loading. */


### PR DESCRIPTION
Events are already defined at:

https://github.com/JustFly1984/react-google-maps-api/blob/1c5a2a7d24f916000ac09ce07c2cf6edcc9168bb/packages/react-google-maps-api/src/GoogleMap.tsx#L15-L16

I'm not sure why, mousedown, mouseup events are not documented on Map instance at https://developers.google.com/maps/documentation/javascript/reference/map?hl=en#Map-Events, but they work (tested).