### PR TITLE
Google marker clusterer

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -93,6 +93,7 @@
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "1.12.5",
+    "@googlemaps/markerclusterer": "^1.0.8",
     "@react-google-maps/infobox": "2.5.0",
     "@react-google-maps/marker-clusterer": "2.5.0",
     "@types/google.maps": "3.45.6",

--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -93,7 +93,7 @@
   },
   "dependencies": {
     "@googlemaps/js-api-loader": "1.12.5",
-    "@googlemaps/markerclusterer": "^1.0.8",
+    "@googlemaps/markerclusterer": "1.0.8",
     "@react-google-maps/infobox": "2.5.0",
     "@react-google-maps/marker-clusterer": "2.5.0",
     "@types/google.maps": "3.45.6",

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { GoogleMap, Marker } from '../..'
+import GoogleMarkerClusterer from './GoogleMarkerClusterer'
+
+import { DBScanAlgorithm, GridAlgorithm, KmeansAlgorithm, NoopAlgorithm, Cluster } from '../..'
+
+const mapContainerStyle = {
+  height: '400px',
+  width: '800px',
+}
+
+const center = { lat: -28.024, lng: 140.887 }
+
+const locations: google.maps.LatLngLiteral[] = [
+  { lat: -31.56391, lng: 147.154312 },
+  { lat: -33.718234, lng: 150.363181 },
+  { lat: -33.727111, lng: 150.371124 },
+  { lat: -33.848588, lng: 151.209834 },
+  { lat: -33.851702, lng: 151.216968 },
+  { lat: -34.671264, lng: 150.863657 },
+  { lat: -35.304724, lng: 148.662905 },
+  { lat: -36.817685, lng: 175.699196 },
+  { lat: -36.828611, lng: 175.790222 },
+  { lat: -37.75, lng: 145.116667 },
+  { lat: -37.759859, lng: 145.128708 },
+  { lat: -37.765015, lng: 145.133858 },
+  { lat: -37.770104, lng: 145.143299 },
+  { lat: -37.7737, lng: 145.145187 },
+  { lat: -37.774785, lng: 145.137978 },
+  { lat: -37.819616, lng: 144.968119 },
+  { lat: -38.330766, lng: 144.695692 },
+  { lat: -39.927193, lng: 175.053218 },
+  { lat: -41.330162, lng: 174.865694 },
+  { lat: -42.734358, lng: 147.439506 },
+  { lat: -42.734358, lng: 147.501315 },
+  { lat: -42.735258, lng: 147.438 },
+  { lat: -43.999792, lng: 170.463352 },
+]
+
+function createKey(location: google.maps.LatLngLiteral) {
+  return location.lat + location.lng
+}
+
+export default {
+  title: 'Google Marker Clusterer',
+  component: GoogleMarkerClusterer,
+} as ComponentMeta<typeof GoogleMarkerClusterer>
+
+const Template: ComponentStory<typeof GoogleMarkerClusterer> = (args) => {
+  return (
+    <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
+      <GoogleMarkerClusterer {...args}>
+        {(clusterer) =>
+          locations.map((location) => (
+            // @ts-ignore: clusterer variable does not match required Cluterer type
+            <Marker key={createKey(location)} position={location} clusterer={clusterer} />
+          )) as any
+        }
+      </GoogleMarkerClusterer>
+    </GoogleMap>
+  )
+}
+
+export const Default = Template.bind({})
+
+export const DBScan = Template.bind({})
+DBScan.args = {
+  options: { algorithm: new DBScanAlgorithm({}) },
+}
+
+export const Grid = Template.bind({})
+Grid.args = {
+  options: { algorithm: new GridAlgorithm({ maxDistance: 40000 }) },
+}
+
+export const Kmeans = Template.bind({})
+Kmeans.args = {
+  options: { algorithm: new KmeansAlgorithm({ numberOfClusters: 10 }) },
+}
+
+export const Noop = Template.bind({})
+Noop.args = {
+  options: { algorithm: new NoopAlgorithm({}) },
+}
+
+export const Render = Template.bind({})
+Render.args = {
+  options: {
+    renderer: {
+      render: ({ count, position }: Cluster) =>
+        new google.maps.Marker({
+          label: { text: String(count), color: 'white', fontSize: '10px' },
+          position,
+          // adjust zIndex to be above other markers
+          zIndex: Number(google.maps.Marker.MAX_ZINDEX) + count,
+        }),
+    },
+  },
+}

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
@@ -53,7 +53,6 @@ const Template: ComponentStory<typeof GoogleMarkerClusterer> = (args) => {
       <GoogleMarkerClusterer {...args}>
         {(clusterer) =>
           locations.map((location) => (
-            // @ts-ignore: clusterer variable does not match required Cluterer type
             <Marker key={createKey(location)} position={location} clusterer={clusterer} />
           )) as any
         }

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
@@ -3,7 +3,9 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { GoogleMap, Marker } from '../..'
 import GoogleMarkerClusterer from './GoogleMarkerClusterer'
 
-import { DBScanAlgorithm, GridAlgorithm, KmeansAlgorithm, NoopAlgorithm, Cluster } from '../..'
+import { GoogleMapsMarkerClusterer as gm } from '../..'
+
+const { DBScanAlgorithm, GridAlgorithm, KmeansAlgorithm, NoopAlgorithm } = gm
 
 const mapContainerStyle = {
   height: '400px',
@@ -87,7 +89,7 @@ export const Render = Template.bind({})
 Render.args = {
   options: {
     renderer: {
-      render: ({ count, position }: Cluster) =>
+      render: ({ count, position }: gm.Cluster) =>
         new google.maps.Marker({
           label: { text: String(count), color: 'white', fontSize: '10px' },
           position,

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
@@ -42,10 +42,10 @@ export const useGoogleMarkerClusterer = (options: MarkerClustererOptionsSubset):
  * 
  * Accepts {@link  MarkerClustererOptionsSubset} which is a subset of  {@link MarkerClustererOptions}
  */
-export const GoogleMakerClusterer = ({ children, options }: GoogleMarkerClustererProps) => {
+export const GoogleMarkerClusterer = ({ children, options }: GoogleMarkerClustererProps) => {
   const markerClusterer = useGoogleMarkerClusterer(options)
 
   return markerClusterer !== null ? children(markerClusterer) : null
 }
 
-export default GoogleMakerClusterer
+export default GoogleMarkerClusterer

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect } from 'react'
+import { MarkerClusterer, MarkerClustererOptions } from '@googlemaps/markerclusterer'
+
+import { useGoogleMap } from '../../map-context'
+
+export type MarkerClustererOptionsSubset = Omit<MarkerClustererOptions, 'map' | 'markers'>
+
+export interface GoogleMarkerClustererProps {
+  /** Render prop that exposes marker clusterer to children components
+   * 
+   * The callback function should return a list of Marker components.
+   */
+  children: (markerClusterer: MarkerClusterer) => React.ReactElement<any, any>,
+  /** Subset of {@link MarkerClustererOptions} options 
+   * 
+   * ```
+   * {  
+   *   algorithm?: Algorithm;  
+   *   renderer?: Renderer;  
+   *   onClusterClick?: onClusterClickHandler;  
+   * }
+   * ```
+   */
+  options: MarkerClustererOptionsSubset
+}
+
+export const useGoogleMarkerClusterer = (options: MarkerClustererOptionsSubset): MarkerClusterer | null => {
+  const map = useGoogleMap()
+  const [markerClusterer, setMarkerClusterer] = useState<MarkerClusterer | null>(null)
+
+  useEffect(() => {
+    if (map && markerClusterer === null) {
+      const markerCluster = new MarkerClusterer({ ...options, map })
+      setMarkerClusterer(markerCluster)
+    }
+  }, [map])
+
+  return markerClusterer
+}
+
+/** Wrapper around [@googlemaps/markerclusterer](https://github.com/googlemaps/js-markerclusterer)
+ * 
+ * Accepts {@link  MarkerClustererOptionsSubset} which is a subset of  {@link MarkerClustererOptions}
+ */
+export const GoogleMakerClusterer = ({ children, options }: GoogleMarkerClustererProps) => {
+  const markerClusterer = useGoogleMarkerClusterer(options)
+
+  return markerClusterer !== null ? children(markerClusterer) : null
+}
+
+export default GoogleMakerClusterer

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -6,6 +6,7 @@ import MapContext from '../../map-context'
 import { HasMarkerAnchor } from '../../types'
 
 import { Clusterer } from '@react-google-maps/marker-clusterer'
+import { MarkerClusterer as GoogleClusterer} from '@googlemaps/markerclusterer'
 import { ReactNode } from 'react'
 
 const eventMap = {
@@ -109,7 +110,7 @@ export interface MarkerProps {
   /** All markers are displayed on the map in order of their zIndex, with higher values displaying in front of markers with lower values. By default, markers are displayed according to their vertical position on screen, with lower markers appearing in front of markers further up the screen. */
   zIndex?: number
   /** Render prop that handles clustering markers */
-  clusterer?: Clusterer
+  clusterer?: Clusterer | GoogleClusterer
   /** Clusters are redrawn when a Marker is added unless noClustererRedraw? is set to true. */
   noClustererRedraw?: boolean
   /** This event is fired when the marker icon was clicked. */

--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -25,6 +25,8 @@ export {
 
 export { default as InfoBox, InfoBoxProps } from './components/addons/InfoBox'
 
+export { default as GoogleMarkerClusterer, GoogleMarkerClustererProps } from './components/addons/GoogleMarkerClusterer'
+
 export { default as InfoWindow, InfoWindowProps } from './components/drawing/InfoWindow'
 
 export { default as Polyline, PolylineProps } from './components/drawing/Polyline'

--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -78,3 +78,5 @@ export {
 export { default as Autocomplete, AutocompleteProps } from './components/places/Autocomplete'
 
 export { default as MapContext, useGoogleMap } from './map-context'
+
+export * from '@googlemaps/markerclusterer'

--- a/packages/react-google-maps-api/src/index.ts
+++ b/packages/react-google-maps-api/src/index.ts
@@ -81,4 +81,4 @@ export { default as Autocomplete, AutocompleteProps } from './components/places/
 
 export { default as MapContext, useGoogleMap } from './map-context'
 
-export * from '@googlemaps/markerclusterer'
+export * as GoogleMapsMarkerClusterer from '@googlemaps/markerclusterer'

--- a/packages/react-google-maps-api/yarn.lock
+++ b/packages/react-google-maps-api/yarn.lock
@@ -358,6 +358,16 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
+"@googlemaps/markerclusterer@^1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@googlemaps/markerclusterer/-/markerclusterer-1.0.8.tgz#734eb9351167f5c58b601938e537c578c45864f7"
+  integrity sha512-sri1eksrl/WiXqOC4X4YLfW41lPbJ2g36mOJ6OHEYbr3IbAhwIy86TUpYYnAg5zFXX1WWmgk9iERjxb+TsmDbg==
+  dependencies:
+    "@turf/clusters-dbscan" "^6.4.0"
+    "@turf/clusters-kmeans" "^6.4.0"
+    fast-deep-equal "^3.1.3"
+    supercluster "^7.1.3"
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -714,6 +724,62 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@turf/clone@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.5.0.tgz#895860573881ae10a02dfff95f274388b1cda51a"
+  integrity sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/clusters-dbscan@^6.4.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clusters-dbscan/-/clusters-dbscan-6.5.0.tgz#e01f854d24fac4899009fc6811854424ea8f0985"
+  integrity sha512-SxZEE4kADU9DqLRiT53QZBBhu8EP9skviSyl+FGj08Y01xfICM/RR9ACUdM0aEQimhpu+ZpRVcUK+2jtiCGrYQ==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/distance" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    density-clustering "1.3.0"
+
+"@turf/clusters-kmeans@^6.4.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/clusters-kmeans/-/clusters-kmeans-6.5.0.tgz#aca6f66858af6476b7352a2bbbb392f9ddb7f5b4"
+  integrity sha512-DwacD5+YO8kwDPKaXwT9DV46tMBVNsbi1IzdajZu1JDSWoN7yc7N9Qt88oi+p30583O0UPVkAK+A10WAQv4mUw==
+  dependencies:
+    "@turf/clone" "^6.5.0"
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    "@turf/meta" "^6.5.0"
+    skmeans "0.9.7"
+
+"@turf/distance@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.5.0.tgz#21f04d5f86e864d54e2abde16f35c15b4f36149a"
+  integrity sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
+"@turf/helpers@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-6.5.0.tgz#f79af094bd6b8ce7ed2bd3e089a8493ee6cae82e"
+  integrity sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==
+
+"@turf/invariant@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-6.5.0.tgz#970afc988023e39c7ccab2341bd06979ddc7463f"
+  integrity sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+
+"@turf/meta@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-6.5.0.tgz#b725c3653c9f432133eaa04d3421f7e51e0418ca"
+  integrity sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
 
 "@types/aria-query@^4.2.0":
   version "4.2.2"
@@ -2329,6 +2395,11 @@ delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
+density-clustering@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/density-clustering/-/density-clustering-1.3.0.tgz#dc9f59c8f0ab97e1624ac64930fd3194817dcac5"
+  integrity sha1-3J9ZyPCrl+FiSsZJMP0xlIF9ysU=
 
 depd@~1.1.2:
   version "1.1.2"
@@ -5004,6 +5075,11 @@ jss@10.8.0, jss@^10.0.0:
     array-includes "^3.1.3"
     object.assign "^4.1.2"
 
+kdbush@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-3.0.0.tgz#f8484794d47004cc2d85ed3a79353dbe0abc2bf0"
+  integrity sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==
+
 kebab-case@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/kebab-case/-/kebab-case-1.0.1.tgz#bf734fc95400a3701869215d99a902bd3fe72f60"
@@ -6951,6 +7027,11 @@ sisteransi@^1.0.5:
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+skmeans@0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/skmeans/-/skmeans-0.9.7.tgz#72670cebb728508f56e29c0e10d11e623529ce5d"
+  integrity sha512-hNj1/oZ7ygsfmPZ7ZfN5MUBRoGg1gtpnImuJBgLO0ljQ67DtJuiQaiYdS4lUA6s0KCwnPhGivtC/WRwIZLkHyg==
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -7268,6 +7349,13 @@ strip-json-comments@^3.1.0, strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+supercluster@^7.1.3:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/supercluster/-/supercluster-7.1.4.tgz#6762aabfd985d3390b49f13b815567d5116a828a"
+  integrity sha512-GhKkRM1jMR6WUwGPw05fs66pOFWhf59lXq+Q3J3SxPvhNcmgOtLRV6aVQPMRsmXdpaeFJGivt+t7QXUPL3ff4g==
+  dependencies:
+    kdbush "^3.0.0"
 
 supports-color@^5.3.0:
   version "5.5.0"

--- a/packages/react-google-maps-api/yarn.lock
+++ b/packages/react-google-maps-api/yarn.lock
@@ -358,7 +358,7 @@
   dependencies:
     fast-deep-equal "^3.1.3"
 
-"@googlemaps/markerclusterer@^1.0.8":
+"@googlemaps/markerclusterer@1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@googlemaps/markerclusterer/-/markerclusterer-1.0.8.tgz#734eb9351167f5c58b601938e537c578c45864f7"
   integrity sha512-sri1eksrl/WiXqOC4X4YLfW41lPbJ2g36mOJ6OHEYbr3IbAhwIy86TUpYYnAg5zFXX1WWmgk9iERjxb+TsmDbg==


### PR DESCRIPTION
[@googlemaps/markerclusterer](https://github.com/googlemaps/js-markerclusterer) is an official Google library for marker clusters. According to its home page, it is a continuation of the library in this project. It looks pretty active and well maintained. Adds some new and exciting features to clusters.

It can be used as an option in this project, and the old one is kept for backward compatibility, or it can completely replace the old `MarkerClusterer` at some point.