### PR TITLE
FIX: Allow useStyle (and updateIcon) to use current styles object

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -7,6 +7,7 @@ import { ClusterIconStyle, ClusterIconInfo } from './types'
 export class ClusterIcon {
   cluster: Cluster
   className: string
+  clusterClassName: string
   styles: ClusterIconStyle[]
   center: google.maps.LatLng | undefined
   div: HTMLDivElement | null
@@ -30,7 +31,8 @@ export class ClusterIcon {
   constructor(cluster: Cluster, styles: ClusterIconStyle[]) {
     cluster.getClusterer().extend(ClusterIcon, google.maps.OverlayView)
     this.cluster = cluster
-    this.className = this.cluster.getClusterer().getClusterClass()
+    this.clusterClassName = this.cluster.getClusterer().getClusterClass()
+    this.className = this.clusterClassName
     this.styles = styles
     this.center = undefined
     this.div = null
@@ -309,15 +311,14 @@ export class ClusterIcon {
 
   useStyle(sums: ClusterIconInfo) {
     this.sums = sums
-
-    const style = this.styles[Math.min(this.styles.length - 1, Math.max(0, sums.index - 1))]
+    const styles = this.cluster.getClusterer().getStyles()
+    const style = styles[Math.min(styles.length - 1, Math.max(0, sums.index - 1))]
 
     this.url = style.url
     this.height = style.height
     this.width = style.width
 
-    if (style.className)
-      this.className = `${this.className} ${style.className}`
+    if (style.className) this.className = `${this.clusterClassName} ${style.className}`
 
     this.anchorText = style.anchorText || [0, 0]
     this.anchorIcon = style.anchorIcon || [this.height / 2, this.width / 2]


### PR DESCRIPTION
# Please explain PR reason
If I use the `setStyles` function on the clusterer, it doesn't update the ClusterIconStyle styles in the `ClusterIcon`. After each `clusteringend`, `updateIcon` is ran on each cluster but not with the current ClusterIconStyle styles array. It is ran with the styles array from initialization. 

This fix gets the current styles array from the clusterer when `useStyle` is called. 
Note: assigning `this.className = ${this.className} ${style.className}` would double up classNames since this.className is no longer just the default cluster className. So I added a clusterClassName prop.

### Background
I'm trying to update the Styles at `clusteringend`. I want to edit the `className` of the `ClusterIcon` based on the markers in the cluster. So I have to wait until the clustering ends to get the markers in each cluster to customize the className in the each ClusterIconStyle . And then call `clusterer.setStyles(stylesWithNewClassnames)`. In the clusterer code, after `clusteringend` is triggered, `updateIcon` is called. But I realized it didn't matter which way I did it, I couldn't get `updateIcon` to get called with the clusterers current styles.

Here's an example of my callback at clusteringEnd:
<img width="685" alt="Screen Shot 2021-10-21 at 2 27 55 PM" src="https://user-images.githubusercontent.com/37453448/138335909-6dc4247b-0b16-4b28-8d0c-684f83cd7608.png">
`marker.location.id` is data that I attach to each marker

