### PR TITLE
Fix CSP: remove styles in `innerHTML`

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -212,14 +212,12 @@ export class ClusterIcon {
 
   show() {
     if (this.div && this.center) {
-      let img = '',
-        divTitle = ''
+      let divTitle = ''
 
       // NOTE: values must be specified in px units
       const bp = this.backgroundPosition.split(' ')
 
       const spriteH = parseInt(bp[0].replace(/^\s+|\s+$/g, ''), 10)
-
       const spriteV = parseInt(bp[1].replace(/^\s+|\s+$/g, ''), 10)
 
       const pos = this.getPosFromLatLng(this.center)
@@ -230,79 +228,43 @@ export class ClusterIcon {
         divTitle = this.sums.title
       }
 
-      this.div.style.cssText = this.createCss(pos)
+      this.div.style.cursor = 'pointer'
+      this.div.style.position = 'absolute'
+      this.div.style.top = `${pos.y}px`
+      this.div.style.left = `${pos.x}px`
+      this.div.style.width = `${this.width}px`
+      this.div.style.height = `${this.height}px`
 
-      img =
-        "<img alt='" +
-        divTitle +
-        "' src='" +
-        this.url +
-        "' style='position: absolute; top: " +
-        spriteV +
-        'px; left: ' +
-        spriteH +
-        'px; '
+      const img = document.createElement('img')
+      img.alt = divTitle
+      img.src = this.url
+      img.style.position = 'absolute'
+      img.style.top = `${spriteV}px`
+      img.style.left = `${spriteH}px`
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-      //@ts-ignore
       if (!this.cluster.getClusterer().enableRetinaIcons) {
-        img +=
-          'clip: rect(' +
-          -1 * spriteV +
-          'px, ' +
-          (-1 * spriteH + this.width) +
-          'px, ' +
-          (-1 * spriteV + this.height) +
-          'px, ' +
-          -1 * spriteH +
-          'px);'
+        img.style.clip = `rect(-${spriteV}px, -${spriteH + this.width}px, -${spriteV + this.height}, -${spriteH})`
       }
 
-      img += "'>"
+      const textElm = document.createElement('div')
+      textElm.style.position = 'absolute'
+      textElm.style.top = `${this.anchorText[0]}px`
+      textElm.style.left = `${this.anchorText[1]}px`
+      textElm.style.color = this.textColor
+      textElm.style.fontSize = `${this.textSize}px`
+      textElm.style.fontFamily = this.fontFamily
+      textElm.style.fontWeight = this.fontWeight
+      textElm.style.fontStyle = this.fontStyle
+      textElm.style.textDecoration = this.textDecoration
+      textElm.style.textAlign = 'center'
+      textElm.style.width = `${this.width}px`
+      textElm.style.lineHeight = `${this.height}px`
+      textElm.innerText = `${this.sums?.text}`
 
-      this.div.innerHTML =
-        img +
-        "<div style='" +
-        'position: absolute;' +
-        'top: ' +
-        this.anchorText[0] +
-        'px;' +
-        'left: ' +
-        this.anchorText[1] +
-        'px;' +
-        'color: ' +
-        this.textColor +
-        ';' +
-        'font-size: ' +
-        this.textSize +
-        'px;' +
-        'font-family: ' +
-        this.fontFamily +
-        ';' +
-        'font-weight: ' +
-        this.fontWeight +
-        ';' +
-        'font-style: ' +
-        this.fontStyle +
-        ';' +
-        'text-decoration: ' +
-        this.textDecoration +
-        ';' +
-        'text-align: center;' +
-        'width: ' +
-        this.width +
-        'px;' +
-        'line-height:' +
-        this.height +
-        'px;' +
-        "'>" +
-        // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-        // @ts-ignore
-        this.sums.text +
-        '</div>'
-
+      this.div.innerHTML = ''
+      this.div.appendChild(img)
+      this.div.appendChild(textElm)
       this.div.title = divTitle
-
       this.div.style.display = ''
     }
 
@@ -340,18 +302,6 @@ export class ClusterIcon {
 
   setCenter(center: google.maps.LatLng) {
     this.center = center
-  }
-
-  createCss(pos: google.maps.Point): string {
-    const style = []
-
-    style.push('cursor: pointer;')
-
-    style.push('position: absolute; top: ' + pos.y + 'px; left: ' + pos.x + 'px;')
-
-    style.push('width: ' + this.width + 'px; height: ' + this.height + 'px;')
-
-    return style.join('')
   }
 
   getPosFromLatLng(latlng: google.maps.LatLng): google.maps.Point {

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.stories.tsx
@@ -1,0 +1,119 @@
+import React from 'react'
+import { ComponentStory, ComponentMeta } from '@storybook/react'
+import { GoogleMap, Marker } from '../..'
+import MarkerClusterer from './MarkerClusterer'
+
+import { ClustererOptions, ClusterIconInfo, ClusterIconStyle, MarkerExtended } from '@react-google-maps/marker-clusterer'
+
+const mapContainerStyle = {
+  height: '400px',
+  width: '800px',
+}
+
+const center = { lat: -28.024, lng: 140.887 }
+
+const locations: google.maps.LatLngLiteral[] = [
+  { lat: -31.56391, lng: 147.154312 },
+  { lat: -33.718234, lng: 150.363181 },
+  { lat: -33.727111, lng: 150.371124 },
+  { lat: -33.848588, lng: 151.209834 },
+  { lat: -33.851702, lng: 151.216968 },
+  { lat: -34.671264, lng: 150.863657 },
+  { lat: -35.304724, lng: 148.662905 },
+  { lat: -36.817685, lng: 175.699196 },
+  { lat: -36.828611, lng: 175.790222 },
+  { lat: -37.75, lng: 145.116667 },
+  { lat: -37.759859, lng: 145.128708 },
+  { lat: -37.765015, lng: 145.133858 },
+  { lat: -37.770104, lng: 145.143299 },
+  { lat: -37.7737, lng: 145.145187 },
+  { lat: -37.774785, lng: 145.137978 },
+  { lat: -37.819616, lng: 144.968119 },
+  { lat: -38.330766, lng: 144.695692 },
+  { lat: -39.927193, lng: 175.053218 },
+  { lat: -41.330162, lng: 174.865694 },
+  { lat: -42.734358, lng: 147.439506 },
+  { lat: -42.734358, lng: 147.501315 },
+  { lat: -42.735258, lng: 147.438 },
+  { lat: -43.999792, lng: 170.463352 },
+]
+
+function createKey(location: google.maps.LatLngLiteral) {
+  return location.lat + location.lng
+}
+
+const baseClusterIconStyle: Partial<ClusterIconStyle> = {
+  textColor: '#D40511',
+  fontFamily: 'Arial',
+  fontStyle: 'normal',
+  fontWeight: '700',
+}
+
+const smallClusterIconStyle: ClusterIconStyle = {
+  ...baseClusterIconStyle,
+  url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTIiIGhlaWdodD0iNTIiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGc+PGNpcmNsZSBjeD0iMjYiIGN5PSIyNiIgcj0iMTYiIGZpbGw9IiNGQzAiLz48Y2lyY2xlIGN4PSIyNiIgY3k9IjI2IiByPSIxNS4yNSIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjEuNSIvPjwvZz48L3N2Zz4=',
+  height: 52,
+  width: 52,
+  textSize: 16,
+}
+
+const mediumClusterIconStyle: ClusterIconStyle = {
+  ...baseClusterIconStyle,
+  url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjgiIGhlaWdodD0iNjgiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGc+PGNpcmNsZSBjeD0iMzQiIGN5PSIzNCIgcj0iMjQiIGZpbGw9IiNGQzAiLz48Y2lyY2xlIGN4PSIzNCIgY3k9IjM0IiByPSIyMyIgc3Ryb2tlPSIjZmZmIiBzdHJva2Utd2lkdGg9IjIiLz48L2c+PC9zdmc+',
+  height: 68,
+  width: 68,
+  textSize: 18,
+}
+
+const largeClusterIconStyle: ClusterIconStyle = {
+  ...baseClusterIconStyle,
+  url: 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iOTAiIGhlaWdodD0iOTAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGc+PGNpcmNsZSBjeD0iNDUiIGN5PSI0NSIgcj0iMzUiIGZpbGw9IiNGQzAiLz48Y2lyY2xlIGN4PSI0NSIgY3k9IjQ1IiByPSIzMy41IiBzdHJva2U9IiNmZmYiIHN0cm9rZS13aWR0aD0iMyIvPjwvZz48L3N2Zz4=',
+  height: 90,
+  width: 90,
+  textSize: 22,
+}
+
+const clusterIconStyles = [smallClusterIconStyle, mediumClusterIconStyle, largeClusterIconStyle]
+
+const markerLengthToIndex = (length: number): number => {
+  if (length >= 50) {
+    return 3
+  } else if (length >= 10) {
+    return 2
+  }
+  return 1
+}
+
+const markerClustererCalculator = (markers: MarkerExtended[]): ClusterIconInfo => ({
+  text: `${markers.length}`,
+  index: markerLengthToIndex(markers.length),
+  title: '',
+})
+
+const markerClustererOptions: ClustererOptions = {
+  averageCenter: true,
+  calculator: markerClustererCalculator,
+  maxZoom: 13,
+  styles: clusterIconStyles,
+}
+
+export default {
+  title: 'Marker Clusterer',
+  component: MarkerClusterer,
+} as ComponentMeta<typeof MarkerClusterer>
+
+const Template: ComponentStory<typeof MarkerClusterer> = (args) => {
+  return (
+    <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
+      <MarkerClusterer {...args} options={markerClustererOptions}>
+        {(clusterer) =>
+          locations.map((location) => (
+            <Marker key={createKey(location)} position={location} clusterer={clusterer} />
+          )) as any
+        }
+      </MarkerClusterer>
+    </GoogleMap>
+  )
+}
+
+export const Default = Template.bind({})


### PR DESCRIPTION
# Please explain PR reason

@JustFly1984 We use a strict CSP policy. The policy doesn't allow inline CSS. This prevents us from using the `ClusterIcon` component because the `show` method uses `innerHTML` _with styles in the injected markup_. This PR's rewrites the the `show` method and removes the problematic `innerHTML` with styles. 

Added a storybook story as well. 

