### PR TITLE
Replaces deprecated addDomListener with addListener

### DIFF
--- a/packages/react-google-maps-api-infobox/src/InfoBox.tsx
+++ b/packages/react-google-maps-api-infobox/src/InfoBox.tsx
@@ -146,14 +146,14 @@ export class InfoBox {
 
         for (let i = 0; i < events.length; i++) {
           this.eventListeners.push(
-            google.maps.event.addDomListener(this.div, events[i], cancelHandler)
+            google.maps.event.addListener(this.div, events[i], cancelHandler)
           )
         }
 
         // Workaround for Google bug that causes the cursor to change to a pointer
         // when the mouse moves over a marker underneath InfoBox.
         this.eventListeners.push(
-          google.maps.event.addDomListener(
+          google.maps.event.addListener(
             this.div,
             'mouseover',
             () => {
@@ -165,7 +165,7 @@ export class InfoBox {
         )
       }
 
-      this.contextListener = google.maps.event.addDomListener(
+      this.contextListener = google.maps.event.addListener(
         this.div,
         'contextmenu',
         ignoreHandler
@@ -201,7 +201,7 @@ export class InfoBox {
   addClickHandler(): void {
     if (this.div && this.div.firstChild && this.closeBoxURL !== '') {
       const closeBox = this.div.firstChild
-      this.closeListener = google.maps.event.addDomListener(
+      this.closeListener = google.maps.event.addListener(
         closeBox,
         'click',
         this.getCloseClickHandler()

--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -78,12 +78,12 @@ export class ClusterIcon {
       }
     )
 
-    google.maps.event.addDomListener(this.div, 'mousedown', function onMouseDown() {
+    google.maps.event.addListener(this.div, 'mousedown', function onMouseDown() {
       cMouseDownInCluster = true
       cDraggingMapByCluster = false
     })
 
-    google.maps.event.addDomListener(
+    google.maps.event.addListener(
       this.div,
       'click',
       (event: Event) => {
@@ -136,7 +136,7 @@ export class ClusterIcon {
       }
     )
 
-    google.maps.event.addDomListener(
+    google.maps.event.addListener(
       this.div,
       'mouseover',
       () => {
@@ -150,7 +150,7 @@ export class ClusterIcon {
       }
     )
 
-    google.maps.event.addDomListener(
+    google.maps.event.addListener(
       this.div,
       'mouseout',
       () => {


### PR DESCRIPTION
`addDomListener` was deprecated in Maps JavaScript API [V3.48.9](https://developers.google.com/maps/documentation/javascript/releases#3.48.9) and produces console warnings. This PR replaces usages of `addDomListener` with `addListener` which has LTS.