### PR TITLE
React hooks are available in React 16.8 through 18

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -93,8 +93,8 @@
     "invariant": "2.2.4"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^16.8 || ^17 || ^18",
+    "react-dom": "^16.8 || ^17 || ^18"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.0",


### PR DESCRIPTION
Currently the main branch specifies React 18+ as a peer dependency. The issue comes up when running `npm install` as one must use `--legacy-peer-deps` to override the present limited peerDependency if using an earlier version of React. This patch extends the package.json specification to include 16.8 and 17, which both support hooks and both run the project. 