### PR TITLE
patch(optional_options): Allowing MarkerClusterer options to be optional

### DIFF
--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.tsx
@@ -21,10 +21,10 @@ export interface GoogleMarkerClustererProps {
    * }
    * ```
    */
-  options: MarkerClustererOptionsSubset
+  options?: MarkerClustererOptionsSubset
 }
 
-export function useGoogleMarkerClusterer(options: MarkerClustererOptionsSubset): MarkerClusterer | null {
+export function useGoogleMarkerClusterer(options?: MarkerClustererOptionsSubset): MarkerClusterer | null {
   const map = useGoogleMap()
 
   const [markerClusterer, setMarkerClusterer] = useState<MarkerClusterer | null>(null)


### PR DESCRIPTION
# Please explain PR reason
Google's js-markerclusterer lib allows for completely optional arguments during construction. This will default to the SuperClusterAlgorithm.

https://github.com/googlemaps/js-markerclusterer/blob/69d026ebfca8e3732e3088e234a450409fd63a11/src/markerclusterer.ts#L77
