### PR TITLE
Fix event listeners on ClusterIcon

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -61,6 +61,11 @@ export class ClusterIcon {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     this.setMap(cluster.getMap()) // Note: this causes onAdd to be called
+    this.onBoundsChanged = this.onBoundsChanged.bind(this)
+    this.onMouseDown = this.onMouseDown.bind(this)
+    this.onClick = this.onClick.bind(this)
+    this.onMouseOver = this.onMouseOver.bind(this)
+    this.onMouseOut = this.onMouseOut.bind(this)
   }
 
   onBoundsChanged() {
@@ -252,6 +257,7 @@ export class ClusterIcon {
         divTitle = this.sums.title
       }
 
+      this.div.className = this.className
       this.div.style.cursor = 'pointer'
       this.div.style.position = 'absolute'
       this.div.style.top = `${pos.y}px`
@@ -262,6 +268,8 @@ export class ClusterIcon {
       const img = document.createElement('img')
       img.alt = divTitle
       img.src = this.url
+      img.width = this.width
+      img.height = this.height
       img.style.position = 'absolute'
       img.style.top = `${spriteV}px`
       img.style.left = `${spriteH}px`


### PR DESCRIPTION
This PR adds additional fixes to https://github.com/JustFly1984/react-google-maps-api/issues/3022

Also adding changing the following:
- Fixing the the ClusterIconStyle.className not being added to the div in the first draw
- Adding width and height to the cluster image to match the provided width and height

# Please explain PR reason
Cluster icon events were broken, since the handler function this references the event target.