### PR TITLE
fixed DrawingManagerF onComplete event handlers

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
@@ -63,6 +63,7 @@ function DrawingManagerFunctional({
   onCircleComplete,
   onMarkerComplete,
   onOverlayComplete,
+  onPolygonComplete,
   onPolylineComplete,
   onRectangleComplete,
   onLoad,
@@ -76,6 +77,7 @@ function DrawingManagerFunctional({
   const [markercompleteListener, setMarkerCompleteListener] = useState<google.maps.MapsEventListener | null>(null)
   const [overlaycompleteListener, setOverlayCompleteListener] = useState<google.maps.MapsEventListener | null>(null)
   const [polygoncompleteListener, setPolygonCompleteListener] = useState<google.maps.MapsEventListener | null>(null)
+  const [polylinecompleteListener, setPolylineCompleteListener] = useState<google.maps.MapsEventListener | null>(null)
   const [rectanglecompleteListener, setRectangleCompleteListener] = useState<google.maps.MapsEventListener | null>(null)
 
   // Order does matter
@@ -134,13 +136,25 @@ function DrawingManagerFunctional({
   }, [instance, onOverlayComplete])
 
   useEffect(() => {
-    if (instance && onPolylineComplete) {
+    if (instance && onPolygonComplete) {
       if (polygoncompleteListener !== null) {
         google.maps.event.removeListener(polygoncompleteListener)
       }
 
       setPolygonCompleteListener(
-        google.maps.event.addListener(instance, 'polygoncomplete', onPolylineComplete)
+        google.maps.event.addListener(instance, 'polygoncomplete', onPolygonComplete)
+      )
+    }
+  }, [instance, onPolygonComplete])
+
+  useEffect(() => {
+    if (instance && onPolylineComplete) {
+      if (polylinecompleteListener !== null) {
+        google.maps.event.removeListener(polylinecompleteListener)
+      }
+      
+      setPolylineCompleteListener(
+        google.maps.event.addListener(instance, 'polylinecomplete', onPolylineComplete)
       )
     }
   }, [instance, onPolylineComplete])
@@ -191,9 +205,15 @@ function DrawingManagerFunctional({
       )
     }
 
-    if (onPolylineComplete) {
+    if (onPolygonComplete) {
       setPolygonCompleteListener(
-        google.maps.event.addListener(drawingManager, 'polygoncomplete', onPolylineComplete)
+        google.maps.event.addListener(drawingManager, 'polygoncomplete', onPolygonComplete)
+      )
+    }
+
+    if (onPolylineComplete) {
+      setPolylineCompleteListener(
+        google.maps.event.addListener(drawingManager, 'polylinecomplete', onPolylineComplete)
       )
     }
 
@@ -225,6 +245,10 @@ function DrawingManagerFunctional({
 
         if (polygoncompleteListener) {
           google.maps.event.removeListener(polygoncompleteListener)
+        }
+
+        if (polylinecompleteListener) {
+          google.maps.event.removeListener(polylinecompleteListener)
         }
 
         if (rectanglecompleteListener) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "es2015",
     "jsx": "react-jsx",
     "lib": ["dom"],
-    "rootDir": "src",
+    "rootDir": "packages",
     "declaration": true,
     "declarationDir": "dist",
     "noEmit": true,


### PR DESCRIPTION
fixed `<DrawingManagerF/>`.

`<onPolylineComplete/>` returns correct polyline completed event, previously returned polygon completed event
`<onPolygonComplete/>` returns polygon completed event instead of nothing

# Reason for the PR
Fixed the bug present and showcased in this [#3033](https://github.com/JustFly1984/react-google-maps-api/issues/3033)