### PR TITLE
Handle auth referrer policy

### DIFF
--- a/packages/react-google-maps-api/src/useJsApiLoader.tsx
+++ b/packages/react-google-maps-api/src/useJsApiLoader.tsx
@@ -25,6 +25,7 @@ export function useJsApiLoader({
   preventGoogleFontsLoading,
   // channel,
   mapIds,
+  authReferrerPolicy,
 }: UseLoadScriptOptions): {
   isLoaded: boolean
   loadError: Error | undefined
@@ -50,8 +51,9 @@ export function useJsApiLoader({
       region,
       mapIds,
       nonce,
+      authReferrerPolicy,
     })
-  }, [id, googleMapsApiKey, version, libraries, language, region, mapIds, nonce])
+  }, [id, googleMapsApiKey, version, libraries, language, region, mapIds, nonce, authReferrerPolicy])
 
   useEffect(function effect() {
     if (isLoaded) {

--- a/packages/react-google-maps-api/src/useLoadScript.tsx
+++ b/packages/react-google-maps-api/src/useLoadScript.tsx
@@ -29,6 +29,7 @@ export function useLoadScript({
   preventGoogleFontsLoading,
   channel,
   mapIds,
+  authReferrerPolicy,
 }: UseLoadScriptOptions): {
   isLoaded: boolean
   loadError: Error | undefined
@@ -74,7 +75,8 @@ export function useLoadScript({
     region,
     libraries,
     channel,
-    mapIds
+    mapIds,
+    authReferrerPolicy
   })
 
   useEffect(

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -11,6 +11,7 @@ export interface LoadScriptUrlOptions {
   libraries?: Libraries | undefined
   channel?: string | undefined
   mapIds?: string[] | undefined
+  authReferrerPolicy?: string | undefined
 }
 
 export function makeLoadScriptUrl({
@@ -21,7 +22,8 @@ export function makeLoadScriptUrl({
   region,
   libraries,
   channel,
-  mapIds
+  mapIds,
+  authReferrerPolicy
 }: LoadScriptUrlOptions): string {
   const params = []
 
@@ -58,6 +60,10 @@ export function makeLoadScriptUrl({
 
   if (mapIds && mapIds.length) {
     params.push(`map_ids=${mapIds.join(',')}`)
+  }
+
+  if (authReferrerPolicy) {
+    params.push(`auth_referrer_policy=${authReferrerPolicy}`)
   }
 
   params.push('callback=initMap')

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -11,7 +11,7 @@ export interface LoadScriptUrlOptions {
   libraries?: Libraries | undefined
   channel?: string | undefined
   mapIds?: string[] | undefined
-  authReferrerPolicy?: string | undefined
+  authReferrerPolicy?: 'origin' | undefined
 }
 
 export function makeLoadScriptUrl({


### PR DESCRIPTION
# Description

This PR is a feature request tied to this issue: https://github.com/JustFly1984/react-google-maps-api/issues/3032
This adds the handling of the `auth_referrer_policy` URL parameter by the following components/hooks:
* `<LoadScript/>`
* `useLoadScript`
* `useJsApiLoader`

# Misc

In the interface `LoadScriptUrlOptions`, the `authReferrerPolicy` is defined as being `"origin"` which matches the already defined type used by `js-api-loader`: https://github.com/googlemaps/js-api-loader/blob/main/src/index.ts#L167-L178