### PR TITLE
Fix onCloseClick of InfoWindowF not triggering

### DIFF
--- a/packages/react-google-maps-api/src/components/addons/InfoBox.tsx
+++ b/packages/react-google-maps-api/src/components/addons/InfoBox.tsx
@@ -219,7 +219,7 @@ function InfoBoxFunctional({
 
       if (onCloseClick) {
         setCloseClickListener(
-          google.maps.event.addListener(infoBox, 'circlecomplete', onCloseClick)
+          google.maps.event.addListener(infoBox, 'closeclick', onCloseClick)
         )
       }
 

--- a/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/InfoWindow.tsx
@@ -197,7 +197,7 @@ function InfoWindowFunctional({
 
     if (onCloseClick) {
       setCloseClickListener(
-        google.maps.event.addListener(infoWindow, 'circlecomplete', onCloseClick)
+        google.maps.event.addListener(infoWindow, 'closeclick', onCloseClick)
       )
     }
 


### PR DESCRIPTION
# Please explain PR reason
Using @react-google-maps/api for a project and for some reason, InfoWindowF onCloseClick is not firing. Went through the code and this seems like an obvious fix, althought I'm not sure if it's the only change required.