### PR TITLE
Support `paths` prop in functional polygon version

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
@@ -121,6 +121,7 @@ function PolygonFunctional({
   editable,
   visible,
   path,
+  paths,
   onDblClick,
   onDragEnd,
   onDragStart,
@@ -187,6 +188,12 @@ function PolygonFunctional({
       instance.setPath(path)
     }
   }, [instance, path])
+
+  useEffect(() => {
+    if (typeof paths !== 'undefined' && instance !== null) {
+      instance.setPaths(paths)
+    }
+  }, [instance, paths])
 
   useEffect(() => {
     if (instance && onDblClick) {
@@ -328,6 +335,10 @@ function PolygonFunctional({
 
     if (path) {
       polygon.setPath(path)
+    }
+
+    if (paths) {
+      polygon.setPaths(paths)
     }
 
     if (typeof visible !== 'undefined') {


### PR DESCRIPTION
Adds support for `paths` prop in `<PolygonF />`. Right now this field is specified in props but not used at all, this PR fixes it.
