### PR TITLE
Adding support for HTML elements for cluster icons

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -300,7 +300,8 @@ export class ClusterIcon {
 
       textElm .setAttribute('style', `position: absolute; top: ${this.anchorText[0]}px; left: ${this.anchorText[1]}px; color: ${this.textColor}; font-size: ${this.textSize}px; font-family: ${this.fontFamily}; font-weight: ${this.fontWeight}; fontStyle: ${this.fontStyle}; text-decoration: ${this.textDecoration}; text-align: center; width: ${this.width}px; line-height: ${this.height}px`)
 
-      textElm.innerText = `${this.sums?.text}`
+      if (this.sums?.text) textElm.innerText = `${this.sums?.text}`
+      if (this.sums?.html) textElm.innerHTML = `${this.sums?.html}`
 
       this.div.innerHTML = ''
 

--- a/packages/react-google-maps-api-marker-clusterer/src/types.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/types.tsx
@@ -2,7 +2,8 @@
 export interface ClusterIconInfo {
   text: string
   index: number
-  title: string
+  title?: string
+  html?: string
 }
 
 export type MarkerExtended = google.maps.Marker & {


### PR DESCRIPTION
# Please explain PR reason
It could be useful to support HTML elements inside ClusterIcon, maybe you want to do clustering by a property and instead of showing number you show property name. 
For example, you show a marker displaying tree location - when user zooms out you cluster them based on the group (Park 1, Park 2) instead of number of trees. There it would be useful to support html so you are able to create custom wrappers.