### PR TITLE
Solves issue with the clusterer icon being on top of each other

### DIFF
--- a/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
+++ b/packages/react-google-maps-api-marker-clusterer/src/ClusterIcon.tsx
@@ -280,7 +280,7 @@ export class ClusterIcon {
       const pos = this.getPosFromLatLng(this.center)
 
       this.div.className = this.className
-      this.div .setAttribute('style', `cursor: 'pointer'; position: 'absolute'; top: ${pos !== null ? `${pos.y}px` : '0'}; left: ${pos !== null ? `${pos.x}px` : '0'}; width: ${this.width}px; height: ${this.height}px; `)
+      this.div .setAttribute('style', `cursor: pointer; position: absolute; top: ${pos !== null ? `${pos.y}px` : '0'}; left: ${pos !== null ? `${pos.x}px` : '0'}; width: ${this.width}px; height: ${this.height}px; `)
 
       const img = document.createElement('img')
 


### PR DESCRIPTION
The positioning of the clusterer markers gets invalidated on (at least) Google Chrome because it retains the single quotation marks. 