### PR TITLE
Fix clusterer example

### DIFF
--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
@@ -1,10 +1,8 @@
-
 import { ComponentStory, ComponentMeta } from '@storybook/react'
-import { GoogleMap, MarkerF , GoogleMapsMarkerClusterer as gm } from '../..'
+import { GoogleMap, MarkerF, GoogleMapsMarkerClusterer as gm } from '../..'
 import GoogleMarkerClusterer from './GoogleMarkerClusterer'
 
-
-const { DBScanAlgorithm, GridAlgorithm, KmeansAlgorithm, NoopAlgorithm } = gm
+const { GridAlgorithm, NoopAlgorithm } = gm
 
 const mapContainerStyle = {
   height: '400px',
@@ -54,7 +52,11 @@ const Template: ComponentStory<typeof GoogleMarkerClusterer> = (args) => {
       <GoogleMarkerClusterer {...args}>
         {(clusterer) =>
           locations.map((location) => (
-            <MarkerF key={createKey(location)} position={location} clusterer={clusterer} />
+            <MarkerF
+              key={createKey(location)}
+              position={location}
+              clusterer={clusterer}
+            />
           )) as any
         }
       </GoogleMarkerClusterer>
@@ -64,19 +66,9 @@ const Template: ComponentStory<typeof GoogleMarkerClusterer> = (args) => {
 
 export const Default = Template.bind({})
 
-export const DBScan = Template.bind({})
-DBScan.args = {
-  options: { algorithm: new DBScanAlgorithm({}) },
-}
-
 export const Grid = Template.bind({})
 Grid.args = {
   options: { algorithm: new GridAlgorithm({ maxDistance: 40000 }) },
-}
-
-export const Kmeans = Template.bind({})
-Kmeans.args = {
-  options: { algorithm: new KmeansAlgorithm({ numberOfClusters: 10 }) },
 }
 
 export const Noop = Template.bind({})

--- a/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/GoogleMarkerClusterer.stories.tsx
@@ -50,15 +50,17 @@ const Template: ComponentStory<typeof GoogleMarkerClusterer> = (args) => {
   return (
     <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
       <GoogleMarkerClusterer {...args}>
-        {(clusterer) =>
-          locations.map((location) => (
-            <MarkerF
-              key={createKey(location)}
-              position={location}
-              clusterer={clusterer}
-            />
-          )) as any
-        }
+        {(clusterer) => (
+          <>
+            {locations.map((location) => (
+              <MarkerF
+                key={createKey(location)}
+                position={location}
+                clusterer={clusterer}
+              />
+            ))}
+          </>
+        )}
       </GoogleMarkerClusterer>
     </GoogleMap>
   )

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.md
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.md
@@ -49,13 +49,24 @@ function createKey(location) {
 const MapWithMarkerClusterer = () => {
   return (
     <ScriptLoaded>
-      <GoogleMap id='marker-example' mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
+      <GoogleMap
+        id='marker-example'
+        mapContainerStyle={mapContainerStyle}
+        zoom={3}
+        center={center}
+      >
         <MarkerClusterer options={options}>
-          {(clusterer) =>
-            locations.map((location) => (
-              <MarkerF key={createKey(location)} position={location} clusterer={clusterer} />
-            ))
-          }
+          {(clusterer) => (
+            <>
+              {locations.map((location) => (
+                <MarkerF
+                  key={createKey(location)}
+                  position={location}
+                  clusterer={clusterer}
+                />
+              ))}
+            </>
+          )}
         </MarkerClusterer>
       </GoogleMap>
     </ScriptLoaded>

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.stories.tsx
@@ -2,7 +2,12 @@ import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { GoogleMap, Marker } from '../..'
 import MarkerClusterer from './MarkerClusterer'
 
-import { ClustererOptions, ClusterIconInfo, ClusterIconStyle, MarkerExtended } from '@react-google-maps/marker-clusterer'
+import {
+  ClustererOptions,
+  ClusterIconInfo,
+  ClusterIconStyle,
+  MarkerExtended,
+} from '@react-google-maps/marker-clusterer'
 
 const mapContainerStyle = {
   height: '400px',
@@ -72,7 +77,11 @@ const largeClusterIconStyle: ClusterIconStyle = {
   textSize: 22,
 }
 
-const clusterIconStyles = [smallClusterIconStyle, mediumClusterIconStyle, largeClusterIconStyle]
+const clusterIconStyles = [
+  smallClusterIconStyle,
+  mediumClusterIconStyle,
+  largeClusterIconStyle,
+]
 
 const markerLengthToIndex = (length: number): number => {
   if (length >= 50) {
@@ -83,7 +92,9 @@ const markerLengthToIndex = (length: number): number => {
   return 1
 }
 
-const markerClustererCalculator = (markers: MarkerExtended[]): ClusterIconInfo => ({
+const markerClustererCalculator = (
+  markers: MarkerExtended[]
+): ClusterIconInfo => ({
   text: `${markers.length}`,
   index: markerLengthToIndex(markers.length),
   title: '',
@@ -105,11 +116,17 @@ const Template: ComponentStory<typeof MarkerClusterer> = (args) => {
   return (
     <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
       <MarkerClusterer {...args} options={markerClustererOptions}>
-        {(clusterer) =>
-          locations.map((location) => (
-            <Marker key={createKey(location)} position={location} clusterer={clusterer} />
-          )) as any
-        }
+        {(clusterer) => (
+          <>
+            {locations.map((location) => (
+              <Marker
+                key={createKey(location)}
+                position={location}
+                clusterer={clusterer}
+              />
+            ))}
+          </>
+        )}
       </MarkerClusterer>
     </GoogleMap>
   )

--- a/packages/react-google-maps-api/src/components/addons/MarkerClustererF.stories.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClustererF.stories.tsx
@@ -1,8 +1,13 @@
 import { ComponentStory, ComponentMeta } from '@storybook/react'
 import { GoogleMap, Marker } from '../..'
-import { MarkerClustererF} from './MarkerClusterer'
+import { MarkerClustererF } from './MarkerClusterer'
 
-import { ClustererOptions, ClusterIconInfo, ClusterIconStyle, MarkerExtended } from '@react-google-maps/marker-clusterer'
+import {
+  ClustererOptions,
+  ClusterIconInfo,
+  ClusterIconStyle,
+  MarkerExtended,
+} from '@react-google-maps/marker-clusterer'
 
 const mapContainerStyle = {
   height: '400px',
@@ -72,7 +77,11 @@ const largeClusterIconStyle: ClusterIconStyle = {
   textSize: 22,
 }
 
-const clusterIconStyles = [smallClusterIconStyle, mediumClusterIconStyle, largeClusterIconStyle]
+const clusterIconStyles = [
+  smallClusterIconStyle,
+  mediumClusterIconStyle,
+  largeClusterIconStyle,
+]
 
 const markerLengthToIndex = (length: number): number => {
   if (length >= 50) {
@@ -83,7 +92,9 @@ const markerLengthToIndex = (length: number): number => {
   return 1
 }
 
-const markerClustererCalculator = (markers: MarkerExtended[]): ClusterIconInfo => ({
+const markerClustererCalculator = (
+  markers: MarkerExtended[]
+): ClusterIconInfo => ({
   text: `${markers.length}`,
   index: markerLengthToIndex(markers.length),
   title: '',
@@ -105,11 +116,17 @@ const Template: ComponentStory<typeof MarkerClustererF> = (args) => {
   return (
     <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
       <MarkerClustererF {...args} options={markerClustererOptions}>
-        {(clusterer) =>
-          locations.map((location) => (
-            <Marker key={createKey(location)} position={location} clusterer={clusterer} />
-          )) as any
-        }
+        {(clusterer) => (
+          <>
+            {locations.map((location) => (
+              <Marker
+                key={createKey(location)}
+                position={location}
+                clusterer={clusterer}
+              />
+            ))}
+          </>
+        )}
       </MarkerClustererF>
     </GoogleMap>
   )


### PR DESCRIPTION
This PR fixes issue of typescript error and eslint warning, occurring when adding marker cluster according to the documentation examples
Fixes same issues in clusterer.stories files.