### PR TITLE
Fix: Point not placed on click in `Data` example

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Data.md
+++ b/packages/react-google-maps-api/src/components/drawing/Data.md
@@ -33,6 +33,10 @@ const onLoad = data => {
         drawingMode: "Point", //  "LineString" or "Polygon".
         featureFactory: geometry => {
           console.log("geometry: ", geometry);
+          return {
+            id: '1',
+            geometry,
+          }
         },
         // Type:  boolean
         // If true, the marker receives mouse and touch events. Default value is true.


### PR DESCRIPTION
Point was not placed in [Data](https://react-google-maps-api-docs.netlify.app/#data)  example when we click on map.

# Please explain PR reason
Fix example