### PR TITLE
feat: export GoogleMapState

### DIFF
--- a/packages/react-google-maps-api/src/GoogleMap.tsx
+++ b/packages/react-google-maps-api/src/GoogleMap.tsx
@@ -60,7 +60,7 @@ const updaterMap = {
   },
 }
 
-interface GoogleMapState {
+export interface GoogleMapState {
   map: google.maps.Map | null
 }
 


### PR DESCRIPTION
This commit ensures the GoogleMapState interface is exported to be used when importing the library.

# Please explain PR reason

I need this type to run the example on https://www.npmjs.com/package/@react-google-maps/api.
