### PR TITLE
refactor: Ensure `react/jsx-runtime` isn't inlined into bundle

### DIFF
--- a/packages/react-google-maps-api/rollup.config.js
+++ b/packages/react-google-maps-api/rollup.config.js
@@ -13,6 +13,7 @@ const output = (format) => {
     globals: {
       react: 'React',
       'react-dom': 'ReactDOM',
+      'react/jsx-runtime': 'ReactJSXRuntime'
     },
   }
 
@@ -28,7 +29,7 @@ const output = (format) => {
 export default [
   {
     plugins: [typescript(), nodeResolve(), commonjs()],
-    external: ['react', 'react-dom'],
+    external: ['react', 'react-dom', 'react/jsx-runtime'],
 
     input: 'src/index.ts',
     output: [...output('cjs'), ...output('umd'), ...output('esm')],


### PR DESCRIPTION
Currently, `react/jsx-runtime` is being inline into your bundles due to it not being marked as external. You can plainly see this in the built bundles, [React's license acts as an easy to spot annotation](https://www.runpkg.com/?@react-google-maps/api@2.17.1/dist/esm.js#14).

This bloats the bundle and makes it incompatible with Preact (see https://github.com/preactjs/preact/issues/3870), as React cannot be aliased out if it's being inlined.