### PR TITLE
Updating its own load state if it was already loaded externally

### DIFF
--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -54,6 +54,16 @@ class LoadScript extends PureComponent<LoadScriptProps, LoadScriptState> {
       if (window.google && window.google.maps && !cleaningUp) {
         console.error('google api is already presented')
 
+        if (this.props.onLoad) {
+          this.props.onLoad()
+        }
+
+        this.setState(function setLoaded() {
+          return {
+            loaded: true,
+          }
+        })
+
         return
       }
 


### PR DESCRIPTION
If the `LoadScript` sees the Google API already loaded, it should proceed to mount its children components. Right now, it gets stuck in the loading state, showing just the console message. Instead, it needs to consider its work 'done'.