### PR TITLE
Use Partial for boxStyle type

### DIFF
--- a/packages/react-google-maps-api-infobox/src/types.tsx
+++ b/packages/react-google-maps-api-infobox/src/types.tsx
@@ -1,7 +1,7 @@
 export interface InfoBoxOptions {
   alignBottom?: boolean | undefined
   boxClass?: string | undefined
-  boxStyle?: CSSStyleDeclaration | undefined
+  boxStyle?: Partial<CSSStyleDeclaration> | undefined
   closeBoxMargin?: string | undefined
   closeBoxURL?: string | undefined
   content?: string | Node | undefined


### PR DESCRIPTION
As described in #3263, the current type of `boxStyle` requires ALL CSS style properties to be added. The type should probably use a `Partial<T>` to allow for *some* properties to be added.

Closes #3263

# Please explain PR reason

See the linked issue #3263 😊 
