### PR TITLE
Fix bug that prevented null from being passed as a drawingMode

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/DrawingManager.tsx
@@ -94,8 +94,8 @@ function DrawingManagerFunctional({
   }, [instance, options])
 
   useEffect(() => {
-    if (drawingMode && instance !== null) {
-      instance.setDrawingMode(drawingMode)
+    if (instance !== null) {
+      instance.setDrawingMode(drawingMode ?? null)
     }
   }, [instance, drawingMode])
 


### PR DESCRIPTION
It was not possible to cancel the current drawingMode (polygon, etc) by passing null. The condition inside the useEffect only accepted truthy values for drawingMode, making it impossible to exit a selected drawingMode.