### PR TITLE
Add `onEdit` to Polygon

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
@@ -113,6 +113,8 @@ export interface PolygonProps {
   onLoad?: ((polygon: google.maps.Polygon) => void) | undefined
   /** This callback is called when the component unmounts. It is called with the polygon instance. */
   onUnmount?: ((polygon: google.maps.Polygon) => void) | undefined
+  /** This callback is called when the components editing is finished */
+  onEdit?: ((polygon: google.maps.Polygon) => void) | undefined
 }
 
 function PolygonFunctional({
@@ -135,6 +137,7 @@ function PolygonFunctional({
   onDrag,
   onLoad,
   onUnmount,
+  onEdit,
 }: PolygonProps): null {
   const map = useContext<google.maps.Map | null>(MapContext)
 
@@ -206,6 +209,18 @@ function PolygonFunctional({
       )
     }
   }, [onDblClick])
+
+  useEffect(() => {
+    if (instance) {
+      google.maps.event.addListener(instance.getPath(), 'insert_at', () => {
+        onEdit?.(instance)
+      });
+
+      google.maps.event.addListener(instance.getPath(), 'set_at', () => {
+        onEdit?.(instance)
+      });
+    }
+  }, [instance, onEdit])
 
   useEffect(() => {
     if (instance && onDragEnd) {


### PR DESCRIPTION
Add support for two event `insert_at` and `set_at` 

Events are described in API reference but are not currently supported within the library.
I'd like to have it on one of the projects, thanks in advance for taking a look

Let me know if you want anything changed :)

https://developers.google.com/maps/documentation/javascript/reference/event#MVCArray-Events