### PR TITLE
add useEffects in MarkerF for clickable, cursor, icon, label, opacity, shape, title, zIndex

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -272,15 +272,64 @@ function MarkerFunctional({
     }
   }, [instance, position])
 
-    useEffect(() => {
-      if (typeof visible !== 'undefined' && instance !== null) {
-        instance.setVisible(visible)
-      }
-    }, [instance, visible])
+  useEffect(() => {
+    if (typeof visible !== 'undefined' && instance !== null) {
+      instance.setVisible(visible)
+    }
+  }, [instance, visible])
 
   useEffect(() => {
     instance?.setAnimation(animation)
   }, [instance, animation])
+
+  useEffect(() => {
+    if (instance && clickable !== undefined) {
+      instance.setClickable(clickable)
+    }
+  }, [instance, clickable])
+
+  useEffect(() => {
+    if (instance && cursor !== undefined) {
+      instance.setCursor(cursor)
+    }
+  }, [instance, cursor])
+
+  useEffect(() => {
+    if (instance && icon !== undefined) {
+      instance.setIcon(icon)
+    }
+  }, [instance, icon])
+
+  useEffect(() => {
+    if (instance && label !== undefined) {
+      instance.setLabel(label)
+    }
+  }, [instance, label])
+
+  useEffect(() => {
+    if (instance && opacity !== undefined) {
+      instance.setOpacity(opacity)
+    }
+  }, [instance, opacity])
+
+  useEffect(() => {
+    if (instance && shape !== undefined) {
+      instance.setShape(shape)
+    }
+  }, [instance, shape])
+
+  useEffect(() => {
+    if (instance && title !== undefined) {
+      instance.setTitle(title)
+    }
+  }, [instance, title])
+
+  useEffect(() => {
+    if (instance && zIndex !== undefined) {
+      instance.setZIndex(zIndex)
+    }
+  }, [instance, zIndex])
+
 
   useEffect(() => {
     if (instance && onDblClick) {


### PR DESCRIPTION
fixes:

- https://github.com/JustFly1984/react-google-maps-api/issues/3278
- https://github.com/JustFly1984/react-google-maps-api/issues/3066

In MarkerF in https://github.com/JustFly1984/react-google-maps-api/blob/fbf7b24d48ac0030efd9930abb6d56efa64bf4fa/packages/react-google-maps-api/src/components/drawing/Marker.tsx#L180-L283 , there was only `useEffects` for some properties but not for all, which had the problem, that some property changes did not trigger re-render. Most prominent one is `icon`.
