### PR TITLE
Load google maps asynchronously

### DIFF
--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -67,8 +67,7 @@ export function makeLoadScriptUrl({
     params.push(`auth_referrer_policy=${authReferrerPolicy}`)
   }
 
-   //Need to load api asynchronously. Ref: https://developers.google.com/maps/documentation/javascript/overview 
-   params.push('loading=async')
+  params.push('loading=async')
   params.push('callback=initMap')
 
   return `https://maps.googleapis.com/maps/api/js?${params.join('&')}`

--- a/packages/react-google-maps-api/src/utils/make-load-script-url.ts
+++ b/packages/react-google-maps-api/src/utils/make-load-script-url.ts
@@ -67,6 +67,8 @@ export function makeLoadScriptUrl({
     params.push(`auth_referrer_policy=${authReferrerPolicy}`)
   }
 
+   //Need to load api asynchronously. Ref: https://developers.google.com/maps/documentation/javascript/overview 
+   params.push('loading=async')
   params.push('callback=initMap')
 
   return `https://maps.googleapis.com/maps/api/js?${params.join('&')}`


### PR DESCRIPTION
### Reason:
The `make-load-script-url` file does not add `loading=async` to its script. This results in a warning that google maps api should be loaded asynchronously for optimal performance. 

Ref: https://developers.google.com/maps/documentation/javascript/overview

Issue: #3334 