### PR TITLE
Update Polygon onEdit to include remove_at listener

### DIFF
--- a/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Polygon.tsx
@@ -215,6 +215,10 @@ function PolygonFunctional({
       google.maps.event.addListener(instance.getPath(), 'set_at', () => {
         onEdit?.(instance)
       });
+
+      google.maps.event.addListener(instance.getPath(), 'remove_at', () => {
+        onEdit?.(instance)
+      });
     }
   }, [instance, onEdit])
 


### PR DESCRIPTION
Currently when editing a Polygon if you add a new point and and then click the undo button the `onEdit` event does not fire indicating the return to the original path because it is a `remove_at` event. However if you move an existing point and then click the undo button the `onEdit` event _does_ fire since it is a `set_at` event. This is an inconsistent behaviour.

This is fixed by adding a `remove_at` listener to the Polygon's path in the same way as the `insert_at` and `set_at` listeners.