### PR TITLE
Prepare for React 19

### DIFF
--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-directions.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-directions.tsx
@@ -6,6 +6,7 @@ import {
 } from '@react-google-maps/api'
 import * as PropTypes from 'prop-types'
 import {
+  type JSX,
   memo,
   useCallback,
   useMemo,
@@ -31,7 +32,7 @@ interface Props {
   }
 }
 
-function ExampleDirections({ styles }: Props): React.JSX.Element {
+function ExampleDirections({ styles }: Props): JSX.Element {
   const [response, setResponse] = useState<google.maps.DirectionsResult | null>(
     null
   )

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-directions.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-directions.tsx
@@ -31,7 +31,7 @@ interface Props {
   }
 }
 
-function ExampleDirections({ styles }: Props): JSX.Element {
+function ExampleDirections({ styles }: Props): React.JSX.Element {
   const [response, setResponse] = useState<google.maps.DirectionsResult | null>(
     null
   )

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-drawing.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-drawing.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, DrawingManager } from '@react-google-maps/api'
 
@@ -20,7 +20,7 @@ interface Props {
   }
 }
 
-function ExampleDrawing({ styles }: Props): React.JSX.Element {
+function ExampleDrawing({ styles }: Props): JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-drawing.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-drawing.tsx
@@ -20,7 +20,7 @@ interface Props {
   }
 }
 
-function ExampleDrawing({ styles }: Props): JSX.Element {
+function ExampleDrawing({ styles }: Props): React.JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-ground.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-ground.tsx
@@ -31,7 +31,7 @@ interface Props {
   }
 }
 
-function GroundOverlayC(): JSX.Element {
+function GroundOverlayC(): React.JSX.Element {
   return (
     <GroundOverlay
     url='https://www.lib.utexas.edu/maps/historical/newark_nj_1922.jpg'
@@ -42,7 +42,7 @@ function GroundOverlayC(): JSX.Element {
 
 const GroundOverlayComponent = memo(GroundOverlayC)
 
-function ExampleGround({ styles }: Props): JSX.Element{
+function ExampleGround({ styles }: Props): React.JSX.Element{
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-ground.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-ground.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, GroundOverlay } from '@react-google-maps/api'
 
@@ -31,7 +31,7 @@ interface Props {
   }
 }
 
-function GroundOverlayC(): React.JSX.Element {
+function GroundOverlayC(): JSX.Element {
   return (
     <GroundOverlay
     url='https://www.lib.utexas.edu/maps/historical/newark_nj_1922.jpg'
@@ -42,7 +42,7 @@ function GroundOverlayC(): React.JSX.Element {
 
 const GroundOverlayComponent = memo(GroundOverlayC)
 
-function ExampleGround({ styles }: Props): React.JSX.Element{
+function ExampleGround({ styles }: Props): JSX.Element{
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-heatmap.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-heatmap.tsx
@@ -27,7 +27,7 @@ interface Props {
   }
 }
 
-function ExampleHeatmap({ styles }: Props): JSX.Element{
+function ExampleHeatmap({ styles }: Props): React.JSX.Element{
   const data = useMemo(() => {
     return [
       new google.maps.LatLng(37.782, -122.447),

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-heatmap.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-heatmap.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo, useMemo } from 'react'
+import { type CSSProperties, type JSX, memo, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import {
   GoogleMap,
@@ -27,7 +27,7 @@ interface Props {
   }
 }
 
-function ExampleHeatmap({ styles }: Props): React.JSX.Element{
+function ExampleHeatmap({ styles }: Props): JSX.Element{
   const data = useMemo(() => {
     return [
       new google.maps.LatLng(37.782, -122.447),

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-options.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-options.tsx
@@ -31,7 +31,7 @@ interface Props {
   }
 }
 
-function ExampleOptions({ styles }: Props): JSX.Element {
+function ExampleOptions({ styles }: Props): React.JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-options.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-options.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap } from '@react-google-maps/api'
 
@@ -31,7 +31,7 @@ interface Props {
   }
 }
 
-function ExampleOptions({ styles }: Props): React.JSX.Element {
+function ExampleOptions({ styles }: Props): JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-overlay-view.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-overlay-view.tsx
@@ -33,7 +33,7 @@ interface Props {
   }
 }
 
-function ExampleOverlayView({ styles }: Props): JSX.Element {
+function ExampleOverlayView({ styles }: Props): React.JSX.Element {
   const [isShown, setIsShown] = useState(false)
 
   const changeIsShown = useCallback(() => {

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-overlay-view.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-overlay-view.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo, useCallback, useState } from 'react'
+import { type CSSProperties, type JSX, memo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, OverlayViewF, MarkerF, OVERLAY_MOUSE_TARGET, MARKER_LAYER,  } from '@react-google-maps/api'
 
@@ -33,7 +33,7 @@ interface Props {
   }
 }
 
-function ExampleOverlayView({ styles }: Props): React.JSX.Element {
+function ExampleOverlayView({ styles }: Props): JSX.Element {
   const [isShown, setIsShown] = useState(false)
 
   const changeIsShown = useCallback(() => {

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-search-box.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-search-box.tsx
@@ -40,7 +40,7 @@ interface Props {
   }
 }
 
-function ExampleSearchBox({ styles }: Props): JSX.Element{
+function ExampleSearchBox({ styles }: Props): React.JSX.Element{
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-search-box.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-search-box.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, StandaloneSearchBox } from '@react-google-maps/api'
 
@@ -40,7 +40,7 @@ interface Props {
   }
 }
 
-function ExampleSearchBox({ styles }: Props): React.JSX.Element{
+function ExampleSearchBox({ styles }: Props): JSX.Element{
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-shapes.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-shapes.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo, useCallback, useMemo, useState, ChangeEventHandler } from 'react'
+import { type CSSProperties, type JSX, memo, useCallback, useMemo, useState, ChangeEventHandler } from 'react'
 import PropTypes from 'prop-types'
 import {
   GoogleMap,
@@ -143,7 +143,7 @@ interface Props {
   }
 }
 
-function ExampleShapes({ styles }: Props): React.JSX.Element {
+function ExampleShapes({ styles }: Props): JSX.Element {
   const [polylineVisible, setPolylineVisible] = useState(true)
   const [polylineOptions, setPolylineOptions] = useState(
     JSON.stringify(POLYLINE_OPTIONS)

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-shapes.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-shapes.tsx
@@ -143,7 +143,7 @@ interface Props {
   }
 }
 
-function ExampleShapes({ styles }: Props): JSX.Element {
+function ExampleShapes({ styles }: Props): React.JSX.Element {
   const [polylineVisible, setPolylineVisible] = useState(true)
   const [polylineOptions, setPolylineOptions] = useState(
     JSON.stringify(POLYLINE_OPTIONS)

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-traffic.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-traffic.tsx
@@ -24,7 +24,7 @@ interface Props {
   }
 }
 
-function ExampleTraffic({ styles }: Props): JSX.Element {
+function ExampleTraffic({ styles }: Props): React.JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-traffic.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-traffic.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, TrafficLayer } from '@react-google-maps/api'
 
@@ -24,7 +24,7 @@ interface Props {
   }
 }
 
-function ExampleTraffic({ styles }: Props): React.JSX.Element {
+function ExampleTraffic({ styles }: Props): JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-transit.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-transit.tsx
@@ -33,7 +33,7 @@ interface Props {
   }
 }
 
-function ExampleTransit({ styles }: Props): JSX.Element {
+function ExampleTransit({ styles }: Props): React.JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api-gatsby-example/src/examples/example-transit.tsx
+++ b/packages/react-google-maps-api-gatsby-example/src/examples/example-transit.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line node/no-extraneous-import
-import { type CSSProperties, memo } from 'react'
+import { type CSSProperties, type JSX, memo } from 'react'
 import PropTypes from 'prop-types'
 import { GoogleMap, TransitLayer } from '@react-google-maps/api'
 
@@ -33,7 +33,7 @@ interface Props {
   }
 }
 
-function ExampleTransit({ styles }: Props): React.JSX.Element {
+function ExampleTransit({ styles }: Props): JSX.Element {
   return (
     <div className='map'>
       <div className='map-container'>

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -24,7 +24,7 @@ export interface LoadScriptProps extends LoadScriptUrlOptions {
   preventGoogleFontsLoading?: boolean
 }
 
-export function DefaultLoadingElement(): JSX.Element {
+export function DefaultLoadingElement(): React.JSX.Element {
   return <div>{`Loading...`}</div>
 }
 

--- a/packages/react-google-maps-api/src/LoadScript.tsx
+++ b/packages/react-google-maps-api/src/LoadScript.tsx
@@ -1,4 +1,4 @@
-import { createRef, PureComponent, type ReactNode, type RefObject } from 'react'
+import { createRef, type JSX, PureComponent, type ReactNode, type RefObject } from 'react'
 import invariant from 'invariant'
 
 import { injectScript } from './utils/injectscript'
@@ -24,7 +24,7 @@ export interface LoadScriptProps extends LoadScriptUrlOptions {
   preventGoogleFontsLoading?: boolean
 }
 
-export function DefaultLoadingElement(): React.JSX.Element {
+export function DefaultLoadingElement(): JSX.Element {
   return <div>{`Loading...`}</div>
 }
 

--- a/packages/react-google-maps-api/src/__tests__/components/circle.test.tsx
+++ b/packages/react-google-maps-api/src/__tests__/components/circle.test.tsx
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import { type JSX } from "react"
 import { render, cleanup } from "@testing-library/react"
 import GoogleMap from  "../../GoogleMap"
 import Circle, { type CircleProps } from '../../components/drawing/Circle'
@@ -17,7 +18,7 @@ function onCircleLoad(circle: google.maps.Circle) {
   instance = circle
 }
 
-function getCircle(props: CircleProps): React.JSX.Element {
+function getCircle(props: CircleProps): JSX.Element {
   return <GoogleMap><Circle {...props} /></GoogleMap>
 }
 

--- a/packages/react-google-maps-api/src/__tests__/components/circle.test.tsx
+++ b/packages/react-google-maps-api/src/__tests__/components/circle.test.tsx
@@ -1,7 +1,6 @@
 /**
  * @jest-environment jsdom
  */
-import type { JSX } from 'react'
 
 import { render, cleanup } from "@testing-library/react"
 import GoogleMap from  "../../GoogleMap"
@@ -18,7 +17,7 @@ function onCircleLoad(circle: google.maps.Circle) {
   instance = circle
 }
 
-function getCircle(props: CircleProps): JSX.Element {
+function getCircle(props: CircleProps): React.JSX.Element {
   return <GoogleMap><Circle {...props} /></GoogleMap>
 }
 

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
@@ -1,5 +1,6 @@
 import {
   type ContextType,
+  type JSX,
   PureComponent,
   useState,
   memo,
@@ -99,7 +100,7 @@ const defaultOptions = {}
 
 export interface MarkerClustererProps {
   // required
-  children: (markerClusterer: Clusterer) => React.JSX.Element
+  children: (markerClusterer: Clusterer) => JSX.Element
 
   options?: ClustererOptions | undefined
   /** Whether the position of a cluster marker should be the average position of all markers in the cluster. If set to false, the cluster marker is positioned at the location of the first marker added to the cluster. The default value is false. */
@@ -150,7 +151,7 @@ export interface MarkerClustererProps {
 
 function MarkerClustererFunctional(
   props: MarkerClustererProps
-): React.JSX.Element | null {
+): JSX.Element | null {
   const {
     children,
     options,
@@ -565,7 +566,7 @@ export class ClustererComponent extends PureComponent<MarkerClustererProps, Clus
     }
   }
 
-  override render(): React.JSX.Element | null {
+  override render(): JSX.Element | null {
     return this.state.markerClusterer !== null
       ? this.props.children(this.state.markerClusterer)
       : null

--- a/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
+++ b/packages/react-google-maps-api/src/components/addons/MarkerClusterer.tsx
@@ -99,7 +99,7 @@ const defaultOptions = {}
 
 export interface MarkerClustererProps {
   // required
-  children: (markerClusterer: Clusterer) => JSX.Element
+  children: (markerClusterer: Clusterer) => React.JSX.Element
 
   options?: ClustererOptions | undefined
   /** Whether the position of a cluster marker should be the average position of all markers in the cluster. If set to false, the cluster marker is positioned at the location of the first marker added to the cluster. The default value is false. */
@@ -150,7 +150,7 @@ export interface MarkerClustererProps {
 
 function MarkerClustererFunctional(
   props: MarkerClustererProps
-): JSX.Element | null {
+): React.JSX.Element | null {
   const {
     children,
     options,
@@ -565,7 +565,7 @@ export class ClustererComponent extends PureComponent<MarkerClustererProps, Clus
     }
   }
 
-  override render(): JSX.Element | null {
+  override render(): React.JSX.Element | null {
     return this.state.markerClusterer !== null
       ? this.props.children(this.state.markerClusterer)
       : null

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
@@ -10,7 +10,7 @@ import {
   DirectionsRenderer,
 } from '@react-google-maps/api';
 
-function Directions(): JSX.Element {
+function Directions(): React.JSX.Element {
   const [response, setResponse] = useState<google.maps.DirectionsResult | null>(
     null
   );

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.md
@@ -2,7 +2,7 @@
 
 ```jsx
 const ScriptLoaded = require("../../docs/ScriptLoaded").default;
-import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
+import React, { type JSX, memo, useCallback, useMemo, useRef, useState } from 'react';
 
 import {
   GoogleMap,
@@ -10,7 +10,7 @@ import {
   DirectionsRenderer,
 } from '@react-google-maps/api';
 
-function Directions(): React.JSX.Element {
+function Directions(): JSX.Element {
   const [response, setResponse] = useState<google.maps.DirectionsResult | null>(
     null
   );

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
@@ -1,4 +1,4 @@
-import { type ContextType, PureComponent } from 'react'
+import { type ContextType, type JSX, PureComponent } from 'react'
 
 import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../utils/helper'
 
@@ -122,7 +122,7 @@ export class DirectionsRenderer extends PureComponent<
     }
   }
 
-  override render(): React.JSX.Element {
+  override render(): JSX.Element {
     return <></>
   }
 }

--- a/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
+++ b/packages/react-google-maps-api/src/components/directions/DirectionsRenderer.tsx
@@ -122,7 +122,7 @@ export class DirectionsRenderer extends PureComponent<
     }
   }
 
-  override render(): JSX.Element {
+  override render(): React.JSX.Element {
     return <></>
   }
 }

--- a/packages/react-google-maps-api/src/components/dom/OverlayView.stories.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.stories.tsx
@@ -1,5 +1,6 @@
 // eslint-disable-next-line node/no-extraneous-import
 import type { StoryFn, Meta } from '@storybook/react'
+import { type JSX } from "react"
 import GoogleMap from '../../GoogleMap'
 import { OverlayViewF, OVERLAY_LAYER } from './OverlayView'
 
@@ -35,7 +36,7 @@ const Template: StoryFn<typeof OverlayViewF> = () => {
 
   return (
     <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
-      {locations.map((location, index): React.JSX.Element => {return (
+      {locations.map((location, index): JSX.Element => {return (
         <OverlayViewF
           mapPaneName={OVERLAY_LAYER}
           getPixelPositionOffset={getPixelPositionOffset}

--- a/packages/react-google-maps-api/src/components/dom/OverlayView.stories.tsx
+++ b/packages/react-google-maps-api/src/components/dom/OverlayView.stories.tsx
@@ -35,7 +35,7 @@ const Template: StoryFn<typeof OverlayViewF> = () => {
 
   return (
     <GoogleMap mapContainerStyle={mapContainerStyle} zoom={3} center={center}>
-      {locations.map((location, index): JSX.Element => {return (
+      {locations.map((location, index): React.JSX.Element => {return (
         <OverlayViewF
           mapPaneName={OVERLAY_LAYER}
           getPixelPositionOffset={getPixelPositionOffset}

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -219,7 +219,7 @@ function MarkerFunctional({
   onZindexChanged,
   onLoad,
   onUnmount
-}: MarkerProps): JSX.Element | null {
+}: MarkerProps): React.JSX.Element | null {
   const map = useContext<google.maps.Map | null>(MapContext)
 
   const [instance, setInstance] = useState<google.maps.Marker | null>(null)

--- a/packages/react-google-maps-api/src/components/drawing/Marker.tsx
+++ b/packages/react-google-maps-api/src/components/drawing/Marker.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
   type ContextType,
   type ReactElement,
+  type JSX,
 } from 'react'
 
 import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../utils/helper'
@@ -219,7 +220,7 @@ function MarkerFunctional({
   onZindexChanged,
   onLoad,
   onUnmount
-}: MarkerProps): React.JSX.Element | null {
+}: MarkerProps): JSX.Element | null {
   const map = useContext<google.maps.Map | null>(MapContext)
 
   const [instance, setInstance] = useState<google.maps.Marker | null>(null)

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import { Children, type ContextType, createRef, PureComponent, type ReactChild, type RefObject } from 'react'
+import { Children, type ContextType, createRef, PureComponent, type ReactNode, type RefObject } from 'react'
 
 import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../utils/helper'
 
@@ -43,7 +43,7 @@ interface AutocompleteState {
 
 export interface AutocompleteProps {
   // required
-  children: ReactChild
+  children: ReactNode
   /** The area in which to search for places. */
   bounds?: google.maps.LatLngBounds | google.maps.LatLngBoundsLiteral | undefined
   /** The component restrictions. Component restrictions are used to restrict predictions to only those within the parent component. For example, the country. */
@@ -131,7 +131,7 @@ export class Autocomplete extends PureComponent<AutocompleteProps, AutocompleteS
     }
   }
 
-  override render(): JSX.Element {
+  override render(): React.JSX.Element {
     return <div ref={this.containerElement} className={this.props.className}>{Children.only(this.props.children)}</div>
   }
 }

--- a/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
+++ b/packages/react-google-maps-api/src/components/places/Autocomplete.tsx
@@ -1,4 +1,4 @@
-import { Children, type ContextType, createRef, PureComponent, type ReactNode, type RefObject } from 'react'
+import { Children, type ContextType, createRef, type JSX, PureComponent, type ReactNode, type RefObject } from 'react'
 
 import { unregisterEvents, applyUpdatersToPropsAndRegisterEvents } from '../../utils/helper'
 
@@ -131,7 +131,7 @@ export class Autocomplete extends PureComponent<AutocompleteProps, AutocompleteS
     }
   }
 
-  override render(): React.JSX.Element {
+  override render(): JSX.Element {
     return <div ref={this.containerElement} className={this.props.className}>{Children.only(this.props.children)}</div>
   }
 }

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
@@ -111,7 +111,7 @@ class StandaloneSearchBox extends PureComponent<
     }
   }
 
-  override render(): JSX.Element {
+  override render(): React.JSX.Element {
     return <div ref={this.containerElement}>{Children.only(this.props.children)}</div>
   }
 }

--- a/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
+++ b/packages/react-google-maps-api/src/components/places/StandaloneSearchBox.tsx
@@ -1,4 +1,4 @@
-import { Children, type ContextType, createRef, PureComponent, type ReactNode, type RefObject } from 'react'
+import { Children, type ContextType, createRef, type JSX, PureComponent, type ReactNode, type RefObject } from 'react'
 
 import invariant from 'invariant'
 
@@ -111,7 +111,7 @@ class StandaloneSearchBox extends PureComponent<
     }
   }
 
-  override render(): React.JSX.Element {
+  override render(): JSX.Element {
     return <div ref={this.containerElement}>{Children.only(this.props.children)}</div>
   }
 }

--- a/packages/react-google-maps-api/src/docs/DocsApiKeyInput.tsx
+++ b/packages/react-google-maps-api/src/docs/DocsApiKeyInput.tsx
@@ -1,4 +1,4 @@
-import { type ChangeEvent, Component, type FormEvent, type ReactNode } from 'react'
+import { type ChangeEvent, Component, type JSX, type FormEvent, type ReactNode } from 'react'
 import { setKey, getKey } from './docs-api-key'
 
 import LoadScript from '../LoadScript'
@@ -18,7 +18,7 @@ const buttonStyle = {
   marginLeft: '8px',
 }
 
-const loadingElement: React.JSX.Element = <div>Loading...</div>
+const loadingElement: JSX.Element = <div>Loading...</div>
 
 interface DocsApiKeyInputState {
   key: string

--- a/packages/react-google-maps-api/src/docs/DocsApiKeyInput.tsx
+++ b/packages/react-google-maps-api/src/docs/DocsApiKeyInput.tsx
@@ -18,7 +18,7 @@ const buttonStyle = {
   marginLeft: '8px',
 }
 
-const loadingElement: JSX.Element = <div>Loading...</div>
+const loadingElement: React.JSX.Element = <div>Loading...</div>
 
 interface DocsApiKeyInputState {
   key: string

--- a/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
+++ b/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactNode } from 'react'
+import { Component, type JSX, type ReactNode } from 'react'
 
 interface ScriptLoadedState {
   scriptLoaded: boolean
@@ -9,7 +9,7 @@ interface ScriptLoadedProps {
   children: ReactNode | ReactNode[] | Function
 }
 
-function SpanIntro(): React.JSX.Element {
+function SpanIntro(): JSX.Element {
   return (
     <span>
       <a href='#section-introduction'>Enter API Key</a> to see examples
@@ -50,7 +50,7 @@ class ScriptLoaded extends Component<ScriptLoadedProps, ScriptLoadedState> {
     window.clearInterval(this.interval)
   }
 
-  override render(): React.JSX.Element {
+  override render(): JSX.Element {
     if (!this.state.scriptLoaded) {
       return <SpanIntro />
     }

--- a/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
+++ b/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
@@ -9,7 +9,7 @@ interface ScriptLoadedProps {
   children: ReactChild | ReactChildren | Function
 }
 
-function SpanIntro(): JSX.Element {
+function SpanIntro(): React.JSX.Element {
   return (
     <span>
       <a href='#section-introduction'>Enter API Key</a> to see examples
@@ -50,7 +50,7 @@ class ScriptLoaded extends Component<ScriptLoadedProps, ScriptLoadedState> {
     window.clearInterval(this.interval)
   }
 
-  override render(): JSX.Element {
+  override render(): React.JSX.Element {
     if (!this.state.scriptLoaded) {
       return <SpanIntro />
     }

--- a/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
+++ b/packages/react-google-maps-api/src/docs/ScriptLoaded.tsx
@@ -1,4 +1,4 @@
-import { Component, type ReactChild, type ReactChildren } from 'react'
+import { Component, type ReactNode } from 'react'
 
 interface ScriptLoadedState {
   scriptLoaded: boolean
@@ -6,7 +6,7 @@ interface ScriptLoadedState {
 
 interface ScriptLoadedProps {
   // eslint-disable-next-line @typescript-eslint/ban-types
-  children: ReactChild | ReactChildren | Function
+  children: ReactNode | ReactNode[] | Function
 }
 
 function SpanIntro(): React.JSX.Element {


### PR DESCRIPTION
This PR updates the code to eliminate some type problems with React 19 RC.

- Use `React.JSX` instead of global `JSX.`
- Use `React.ReactNode` instead of `React.ReactChild`