### PR TITLE
Include React 19 in peer deps

### DIFF
--- a/packages/react-google-maps-api/package.json
+++ b/packages/react-google-maps-api/package.json
@@ -98,8 +98,8 @@
     "invariant": "2.2.4"
   },
   "peerDependencies": {
-    "react": "^16.8 || ^17 || ^18",
-    "react-dom": "^16.8 || ^17 || ^18"
+    "react": "^16.8 || ^17 || ^18 || ^19",
+    "react-dom": "^16.8 || ^17 || ^18 || ^19"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "25.0.7",


### PR DESCRIPTION
Include React 19 in peer deps for api package, as suggested in https://github.com/JustFly1984/react-google-maps-api/pull/3382#issuecomment-2400559676.
(Note that only one package actually had React as a peer dep.)