### PR TITLE
Remove yarn boostrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Fork original repo at <https://github.com/JustFly1984/react-google-maps-api>. Cl
 - `cd react-google-maps-api` - move to newly created folder
 - `cp .storybook/example.maps.config.ts .storybook/maps.config.ts` - create file with API Key
 - `yarn install` - install dependencies
-- `yarn bootstrap` - setup workspace
 - `yarn storybook` - run storybook server
 
 Any changes you make to src folders of contained packages should reflect on the storybook server.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "prestart:gatsby": "yarn build:clusterer && yarn build:infobox && yarn build:api",
     "clean": "rimraf ./yarn.lock ./package-lock.json ./node_modules/ && yarn",
     "storybook": "start-storybook -p 6006",
-    "bootstrap": "lerna bootstrap",
     "build-storybook": "build-storybook"
   },
   "lint-staged": {


### PR DESCRIPTION
# Reason
`lerna boostrap` command was removed by defult in v7 and Lerna doc recommends to use `yarn install` to setup workspaces (installing dependencies, etc)


